### PR TITLE
Save pressure constraints in IMAS format and store psi at sensor locations

### DIFF
--- a/examples/scan_gsfit__st40__real_data_pressure_constrained.py
+++ b/examples/scan_gsfit__st40__real_data_pressure_constrained.py
@@ -16,8 +16,8 @@ script_start_time = time.perf_counter()
 section_start_time = script_start_time
 
 # ── Pulse numbers ─────────────────────────────────────────────────────────────
-# pulse_num = 13_560
-pulse_num = 13_599
+pulse_num = 13_560
+# pulse_num = 13_599
 pulse_num_write = pulse_num + 52_000_000
 # psu2coil_run_name = "RUN06"
 psu2coil_run_name = "RUN05"
@@ -67,7 +67,7 @@ for i_ts_sensor in range(len(ts_r)):
     measured_pressure_full[measured_pressure_full <= 0.5e3] = np.nan
     if np.any(~np.isnan(measured_pressure_full)):
         pressure_sensors.add_sensor(
-            name=f"TS_{i_ts_sensor + 1}",
+            name=f"PRESSURE{i_ts_sensor + 1:02d}",
             geometry_r=ts_r[i_ts_sensor],
             geometry_z=ts_z[i_ts_sensor],
             fit_settings_comment="",

--- a/python/gsfit/database_writers/tokamak_energy_mdsplus/map_results_to_database.py
+++ b/python/gsfit/database_writers/tokamak_energy_mdsplus/map_results_to_database.py
@@ -199,11 +199,12 @@ def map_results_to_database(
     results["SOL"]["LFS"]["STRIKE_POINT"]["Z"] = plasma.get_array1(["sol", "lfs", "strike_point", "z"])  # shape = [n_time]
 
     if len(pressure_sensors.keys()) > 0:
-        results["CONSTRAINTS"]["PRESSURE"]["CVALUE"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "value"])  # shape = [n_time, n_points]
-        results["CONSTRAINTS"]["PRESSURE"]["MVALUE"] = pressure_sensors.get_array2(["*", "pressure", "measured", "value"])  # shape = [n_time, n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["RECONSTRUCTED"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "value"])  # shape = [n_time, n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["MEASURED"] = pressure_sensors.get_array2(["*", "pressure", "measured", "value"])  # shape = [n_time, n_points]
         results["CONSTRAINTS"]["PRESSURE"]["WEIGHT"] = pressure_sensors.get_array1(["*", "fit_settings", "weight"])  # shape = [n_points]
-        results["CONSTRAINTS"]["PRESSURE"]["R"] = pressure_sensors.get_array1(["*", "geometry", "r"])  # shape = [n_points]
-        results["CONSTRAINTS"]["PRESSURE"]["Z"] = pressure_sensors.get_array1(["*", "geometry", "z"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["R"] = pressure_sensors.get_array1(["*", "geometry", "r"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["Z"] = pressure_sensors.get_array1(["*", "geometry", "z"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["PSI"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "psi"])  # shape = [n_time, n_points]
  
     # Store "WORKFLOW"
     database_reader_method = settings["GSFIT_code_settings.json"]["database_reader"]["method"]

--- a/python/gsfit/database_writers/tokamak_energy_mdsplus_new/map_results_to_database.py
+++ b/python/gsfit/database_writers/tokamak_energy_mdsplus_new/map_results_to_database.py
@@ -27,6 +27,7 @@ def map_results_to_database(
     rogowski_coils = gsfit_controller.rogowski_coils
     passives = gsfit_controller.passives
     coils = gsfit_controller.coils
+    pressure_sensors = gsfit_controller.pressure_sensors
     results = gsfit_controller.results
 
     # Plasma boundary
@@ -216,6 +217,14 @@ def map_results_to_database(
     results["SOL"]["LFS"]["CONTOUR"]["N"] = np.array(plasma.get_vec_usize(["sol", "lfs", "contour", "n"])).astype(np.int32)  # shape = [n_time]
     results["SOL"]["LFS"]["STRIKE_POINT"]["R"] = plasma.get_array1(["sol", "lfs", "strike_point", "r"])  # shape = [n_time]
     results["SOL"]["LFS"]["STRIKE_POINT"]["Z"] = plasma.get_array1(["sol", "lfs", "strike_point", "z"])  # shape = [n_time]
+
+    if len(pressure_sensors.keys()) > 0:
+        results["CONSTRAINTS"]["PRESSURE"]["RECONSTRUCTED"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "value"])  # shape = [n_time, n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["MEASURED"] = pressure_sensors.get_array2(["*", "pressure", "measured", "value"])  # shape = [n_time, n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["WEIGHT"] = pressure_sensors.get_array1(["*", "fit_settings", "weight"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["R"] = pressure_sensors.get_array1(["*", "geometry", "r"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["Z"] = pressure_sensors.get_array1(["*", "geometry", "z"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["PSI"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "psi"])  # shape = [n_time, n_points]
 
     # Store "WORKFLOW"
     database_reader_method = settings["GSFIT_code_settings.json"]["database_reader"]["method"]

--- a/python/gsfit/database_writers/tokamak_energy_mdsplus_new/map_results_to_database.py
+++ b/python/gsfit/database_writers/tokamak_energy_mdsplus_new/map_results_to_database.py
@@ -219,12 +219,26 @@ def map_results_to_database(
     results["SOL"]["LFS"]["STRIKE_POINT"]["Z"] = plasma.get_array1(["sol", "lfs", "strike_point", "z"])  # shape = [n_time]
 
     if len(pressure_sensors.keys()) > 0:
-        results["CONSTRAINTS"]["PRESSURE"]["RECONSTRUCTED"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "value"])  # shape = [n_time, n_points]
-        results["CONSTRAINTS"]["PRESSURE"]["MEASURED"] = pressure_sensors.get_array2(["*", "pressure", "measured", "value"])  # shape = [n_time, n_points]
-        results["CONSTRAINTS"]["PRESSURE"]["WEIGHT"] = pressure_sensors.get_array1(["*", "fit_settings", "weight"])  # shape = [n_points]
-        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["R"] = pressure_sensors.get_array1(["*", "geometry", "r"])  # shape = [n_points]
-        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["Z"] = pressure_sensors.get_array1(["*", "geometry", "z"])  # shape = [n_points]
-        results["CONSTRAINTS"]["PRESSURE"]["POSITION"]["PSI"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "psi"])  # shape = [n_time, n_points]
+        sensor_names = list(pressure_sensors.keys())
+
+        # Per-sensor nodes (PRESSURE01, PRESSURE02, ...)
+        for i, sensor_name in enumerate(sensor_names):
+            node_name = f"PRESSURE{i + 1:02d}"
+            results["CONSTRAINTS"]["PRESSURE"][node_name]["MEASURED"] = pressure_sensors.get_array1([sensor_name, "pressure", "measured", "value"])  # shape = [n_time]
+            results["CONSTRAINTS"]["PRESSURE"][node_name]["RECONSTRUCT"] = pressure_sensors.get_array1([sensor_name, "pressure", "calculated", "value"])  # shape = [n_time]
+            results["CONSTRAINTS"]["PRESSURE"][node_name]["WEIGHT"] = pressure_sensors.get_f64([sensor_name, "fit_settings", "weight"])  # scalar
+            results["CONSTRAINTS"]["PRESSURE"][node_name]["POSITION"]["R"] = pressure_sensors.get_f64([sensor_name, "geometry", "r"])  # scalar
+            results["CONSTRAINTS"]["PRESSURE"][node_name]["POSITION"]["Z"] = pressure_sensors.get_f64([sensor_name, "geometry", "z"])  # scalar
+            results["CONSTRAINTS"]["PRESSURE"][node_name]["POSITION"]["PSI"] = pressure_sensors.get_array1([sensor_name, "pressure", "calculated", "psi"])  # shape = [n_time]
+
+        # ALL aggregate node
+        results["CONSTRAINTS"]["PRESSURE"]["ALL"]["MEASURED"] = pressure_sensors.get_array2(["*", "pressure", "measured", "value"])  # shape = [n_time, n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["ALL"]["RECONSTRUCT"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "value"])  # shape = [n_time, n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["ALL"]["WEIGHT"] = pressure_sensors.get_array1(["*", "fit_settings", "weight"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["ALL"]["POSITION"]["R"] = pressure_sensors.get_array1(["*", "geometry", "r"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["ALL"]["POSITION"]["Z"] = pressure_sensors.get_array1(["*", "geometry", "z"])  # shape = [n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["ALL"]["POSITION"]["PSI"] = pressure_sensors.get_array2(["*", "pressure", "calculated", "psi"])  # shape = [n_time, n_points]
+        results["CONSTRAINTS"]["PRESSURE"]["ALL"]["NAMES"] = sensor_names
 
     # Store "WORKFLOW"
     database_reader_method = settings["GSFIT_code_settings.json"]["database_reader"]["method"]

--- a/python/gsfit/settings/default/GSFIT_code_settings.json
+++ b/python/gsfit/settings/default/GSFIT_code_settings.json
@@ -67,7 +67,7 @@
         }
     },
     "database_writer": {
-        "method": "tokamak_energy_mdsplus",
+        "method": "tokamak_energy_mdsplus_new",
         "tokamak_energy_mdsplus": {
         },
         "tokamak_energy_mdsplus_no_workflow": {

--- a/rust/gsfit_rs/src/sensors/pressure.rs
+++ b/rust/gsfit_rs/src/sensors/pressure.rs
@@ -452,6 +452,7 @@ impl Pressure {
 
         for sensor_name in &sensor_names {
             let mut sensor_values: Array1<f64> = Array1::from_elem(n_time, f64::NAN);
+            let mut psi_values: Array1<f64> = Array1::from_elem(n_time, f64::NAN);
 
             // Find the value of psi_n at the location of the pressure sensor
             let sensor_r: f64 = self.results.get(sensor_name).get("geometry").get("r").unwrap_f64();
@@ -531,6 +532,8 @@ impl Pressure {
 
                 let psi_n_at_sensor: f64 = (psi_at_sensor - psi_a) / (psi_b - psi_a);
 
+                psi_values[i_time] = psi_at_sensor;
+
                 // If sensor is outside the plasma boundary, leave sensor_values[i_time] as NaN
                 if !(0.0..=1.0).contains(&psi_n_at_sensor) {
                     continue;
@@ -551,6 +554,11 @@ impl Pressure {
                 .get_or_insert("pressure")
                 .get_or_insert("calculated")
                 .insert("value", sensor_values);
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("pressure")
+                .get_or_insert("calculated")
+                .insert("psi", psi_values);
             self.results
                 .get_or_insert(sensor_name)
                 .get_or_insert("pressure")


### PR DESCRIPTION
Two changes in this PR:

### `pressure.rs`
Added `psi_values` array to `calculate_sensor_values_rust`. For each pressure sensor we now store the absolute psi (Webers) at the sensor location under `["pressure"]["calculated"]["psi"]`. This is stored before the LCFS boundary check so we always get a value even when the sensor is outside the plasma.

### `map_results_to_database.py`
Updated the pressure constraint block in the Tokamak Energy MDSplus writer to match IMAS naming conventions:
- `CVALUE` → `RECONSTRUCTED`
- `MVALUE` → `MEASURED`
- `R`, `Z` → `POSITION/R`, `POSITION/Z`
- Added `POSITION/PSI` — the reconstructed psi (Webers) at each sensor location vs time, shape `[n_time, n_points]`