### PR TITLE
Add diamagnetic flux loop (DIALOOP) as a fit constraint

### DIFF
--- a/examples/example_12__st40__dialoop_example.py
+++ b/examples/example_12__st40__dialoop_example.py
@@ -15,7 +15,7 @@ gsfit_controller = Gsfit(
 )
 gsfit_controller.settings["sensor_weights_dialoop.json"]["DIALOOP"]["fit_settings"]["weight"] = 1e2
 gsfit_controller.settings["sensor_weights_dialoop.json"]["DIALOOP"]["fit_settings"]["include"] = True
-# Need to lower 
+# Need to lower time_end from 250ms to 249ms since DIALOOP doesn't have data at 250ms
 gsfit_controller.settings["GSFIT_code_settings.json"]["timeslices"]["arange"]["time_end"] = 249.0e-3
 
 # Run

--- a/examples/example_12__st40__dialoop_example.py
+++ b/examples/example_12__st40__dialoop_example.py
@@ -1,0 +1,22 @@
+# Note, this example will only run inside Tokamak Energy's network
+
+from gsfit import Gsfit
+
+pulseNo = 14_681  # A real experimental shot
+pulseNo_write = pulseNo + 52_000_000  # Write to a "million" modelling pulse number
+
+# Construct the GSFit object
+gsfit_controller = Gsfit(
+    pulseNo=pulseNo,
+    run_name="ITER07",
+    run_description="Testing include=True for DIALOOP sensor, weight=1e2",
+    write_to_mds=True,
+    pulseNo_write=pulseNo_write,
+)
+gsfit_controller.settings["sensor_weights_dialoop.json"]["DIALOOP"]["fit_settings"]["weight"] = 1e2
+gsfit_controller.settings["sensor_weights_dialoop.json"]["DIALOOP"]["fit_settings"]["include"] = True
+# Need to lower 
+gsfit_controller.settings["GSFIT_code_settings.json"]["timeslices"]["arange"]["time_end"] = 249.0e-3
+
+# Run
+gsfit_controller.run()

--- a/python/gsfit/database_readers/st40_mdsplus/setup_dialoop.py
+++ b/python/gsfit/database_readers/st40_mdsplus/setup_dialoop.py
@@ -1,7 +1,9 @@
 import typing
 from typing import TYPE_CHECKING
 
+import mdsthin
 import numpy as np
+import numpy.typing as npt
 from gsfit_rs import Dialoop
 from st40_database import GetData
 
@@ -28,16 +30,47 @@ def setup_dialoop(
     # Initialise the Dialoop Rust class
     dialoop = Dialoop()
 
-    # TODO: implement the method
+    # Read in the diamagnetic flux from MDSplus
+    dialoop_run_name = settings["GSFIT_code_settings.json"]["database_reader"]["st40_mdsplus"]["workflow"]["dialoop"]["run_name"]
+    mag_run_name = settings["GSFIT_code_settings.json"]["database_reader"]["st40_mdsplus"]["workflow"]["mag"]["run_name"]
+    dialoop_data = GetData(pulseNo, f"DIALOOP#{dialoop_run_name}", is_fail_quiet=False)
 
-    # dialoop.add_sensor(
-    #     name="DIALOOP_001",
-    #     fit_settings_comment="",
-    #     fit_settings_expected_value=0.0,
-    #     fit_settings_include=True,
-    #     fit_settings_weight=1.0,
-    #     time=np.array([0.0]),
-    #     measured=np.array([0.0]),
-    # )
+    # We use a single diamagnetic flux loop
+    sensor_name = "DIALOOP"
+
+    # Get geometry (path of integration) directly via mdsthin from the MAG tree
+    # (the geometry is stored in MAG, not in the DIALOOP tree)
+    conn = mdsthin.Connection("smaug")
+    conn.openTree("MAG", pulseNo)
+    path_r = conn.get(f"\\MAG::TOP.{mag_run_name}.DIALOOP.L000:R_PATH").data().astype(np.float64)
+    path_z = conn.get(f"\\MAG::TOP.{mag_run_name}.DIALOOP.L000:Z_PATH").data().astype(np.float64)
+
+    if sensor_name in settings["sensor_weights_dialoop.json"]:
+        fit_settings_comment = settings["sensor_weights_dialoop.json"][sensor_name]["fit_settings"]["comment"]
+        fit_settings_expected_value = settings["sensor_weights_dialoop.json"][sensor_name]["fit_settings"]["expected_value"]
+        fit_settings_include = settings["sensor_weights_dialoop.json"][sensor_name]["fit_settings"]["include"]
+        fit_settings_weight = settings["sensor_weights_dialoop.json"][sensor_name]["fit_settings"]["weight"]
+    else:
+        fit_settings_comment = ""
+        fit_settings_expected_value = np.nan
+        fit_settings_include = False
+        fit_settings_weight = np.nan
+
+    # Measured signal: \DIALOOP::TOP.<run_name>.GLOBAL:PHI_DIA
+    time = typing.cast(npt.NDArray[np.float64], dialoop_data.get("TIME")).astype(np.float64)
+    measured = typing.cast(npt.NDArray[np.float64], dialoop_data.get("GLOBAL.PHI_DIA")).astype(np.float64)
+
+    # Add the sensor to the Rust class
+    dialoop.add_sensor(
+        name=sensor_name,
+        r=path_r,
+        z=path_z,
+        fit_settings_comment=fit_settings_comment,
+        fit_settings_expected_value=fit_settings_expected_value,
+        fit_settings_include=fit_settings_include,
+        fit_settings_weight=fit_settings_weight,
+        time=time,
+        measured=measured,
+    )
 
     return dialoop

--- a/python/gsfit/database_writers/tokamak_energy_mdsplus_new/map_results_to_database.py
+++ b/python/gsfit/database_writers/tokamak_energy_mdsplus_new/map_results_to_database.py
@@ -24,6 +24,7 @@ def map_results_to_database(
     plasma = gsfit_controller.plasma
     bp_probes = gsfit_controller.bp_probes
     flux_loops = gsfit_controller.flux_loops
+    dialoop = gsfit_controller.dialoop
     rogowski_coils = gsfit_controller.rogowski_coils
     passives = gsfit_controller.passives
     coils = gsfit_controller.coils
@@ -134,6 +135,13 @@ def map_results_to_database(
         results["CONSTRAINTS"]["ROGOWSKI"][sensor_name]["MEASURED"] = rogowski_coils.get_array1([sensor_name, "i", "measured", "value"])
         results["CONSTRAINTS"]["ROGOWSKI"][sensor_name]["RECONSTRUCT"] = rogowski_coils.get_array1([sensor_name, "i", "calculated", "value"])
         results["CONSTRAINTS"]["ROGOWSKI"][sensor_name]["WEIGHT"] = rogowski_coils.get_f64([sensor_name, "fit_settings", "weight"])
+
+    # Diamagnetic flux (single diamagnetic flux loop "DIALOOP")
+    for sensor_name in dialoop.keys():
+        results["CONSTRAINTS"]["DIAMAG_FLUX"]["INCLUDE"] = np.int32(dialoop.get_bool([sensor_name, "fit_settings", "include"]))
+        results["CONSTRAINTS"]["DIAMAG_FLUX"]["MEASURED"] = dialoop.get_array1([sensor_name, "b", "measured", "value"])
+        results["CONSTRAINTS"]["DIAMAG_FLUX"]["RECONSTRUCT"] = dialoop.get_array1([sensor_name, "b", "calculated", "value"])
+        results["CONSTRAINTS"]["DIAMAG_FLUX"]["WEIGHT"] = dialoop.get_f64([sensor_name, "fit_settings", "weight"])
 
     for pf_name in coils.keys(["pf"]):
         # results["CONSTRAINTS"]["PF_CURRENT"][pf_name]["EXACT"]

--- a/python/gsfit/gsfit.py
+++ b/python/gsfit/gsfit.py
@@ -48,6 +48,7 @@ class Gsfit(DiagnosticAndSimulationBase):
     isoflux_boundary: gsfit_rs.IsofluxBoundary
     pressure_sensors: gsfit_rs.Pressure
     stationary_point: gsfit_rs.StationaryPoint
+    dialoop: gsfit_rs.Dialoop
 
     # TODO: move to DiagnosticAndSimulationBase
     def __getitem__(self, key: str) -> typing.Any:
@@ -187,6 +188,7 @@ class Gsfit(DiagnosticAndSimulationBase):
         isoflux_boundary = self.isoflux_boundary
         pressure_sensors = self.pressure_sensors
         stationary_point = self.stationary_point
+        dialoop = self.dialoop
 
         times_to_reconstruct = self.results["TIME"]
 
@@ -204,6 +206,7 @@ class Gsfit(DiagnosticAndSimulationBase):
             isoflux_boundary,
             pressure_sensors,
             stationary_point,
+            dialoop,
             times_to_reconstruct,
             self.settings["GSFIT_code_settings.json"]["numerics"]["n_iter_max"],
             self.settings["GSFIT_code_settings.json"]["numerics"]["n_iter_min"],
@@ -342,3 +345,8 @@ class Gsfit(DiagnosticAndSimulationBase):
         )
         toc = time_py.time()
         self.logger.info(msg=f"`stationary_point` initialised;  {(toc - tic) * 1e3:,.2f}ms")
+
+        tic = time_py.time()
+        self.dialoop = database_reader.setup_dialoop(pulseNo=self.pulseNo, settings=self.settings, **kwargs)
+        toc = time_py.time()
+        self.logger.info(msg=f"`dialoop` initialised;  {(toc - tic) * 1e3:,.2f}ms")

--- a/python/gsfit/settings/default/GSFIT_code_settings.json
+++ b/python/gsfit/settings/default/GSFIT_code_settings.json
@@ -18,6 +18,11 @@
                     "pulseNo": null,
                     "run_name": "RUN06",
                     "usage": "PF and TF coil currents"
+                },
+                "dialoop": {
+                    "pulseNo": null,
+                    "run_name": "BEST",
+                    "usage": "Diamagnetic flux measured value"
                 }
             },
             "isoflux_code_name": null

--- a/python/gsfit/settings/default/sensor_weights_dialoop.json
+++ b/python/gsfit/settings/default/sensor_weights_dialoop.json
@@ -1,3 +1,10 @@
 {
-    
+    "DIALOOP": {
+        "fit_settings": {
+            "expected_value": 0.005,
+            "weight": 1.0e2,
+            "include": false,
+            "comment": ""
+        }
+    }
 }

--- a/python/gsfit_rs/gsfit_rs.pyi
+++ b/python/gsfit_rs/gsfit_rs.pyi
@@ -68,6 +68,7 @@ def solve_grad_shafranov(
     isoflux_boundary: IsofluxBoundary,
     pressure_sensors: Pressure,
     stationary_point: StationaryPoint,
+    dialoop: Dialoop,
     times_to_reconstruct: npt.NDArray[np.float64],
     n_iter_max: int,
     n_iter_min: int,
@@ -87,6 +88,7 @@ def solve_grad_shafranov(
     :param isoflux_boundary: IsofluxBoundary object, note this is mutated and contains the solution
     :param pressure_sensors: Pressure object, note this is mutated and contains the solution
     :param stationary_point: StationaryPoint object, note this is mutated and contains the solution
+    :param dialoop: Dialoop object, note this is mutated and contains the solution
     :param times_to_reconstruct: Times to reconstruct [second]
     :param n_iter_max: Maximum number of iterations
     :param n_iter_min: Minimum number of iterations
@@ -611,8 +613,8 @@ class Dialoop(DataTreeAccessor):
     def add_sensor(
         cls,
         name: str,
-        geometry_r: float,
-        geometry_z: float,
+        r: npt.NDArray[np.float64],
+        z: npt.NDArray[np.float64],
         fit_settings_comment: str,
         fit_settings_expected_value: float,
         fit_settings_include: bool,
@@ -620,24 +622,10 @@ class Dialoop(DataTreeAccessor):
         time: npt.NDArray[np.float64],
         measured: npt.NDArray[np.float64],
     ) -> None: ...
-    # def greens_with_coils(
-    #     cls,
-    #     coils: "Coils",
-    # ) -> None: ...
-    # def greens_with_passives(
-    #     cls,
-    #     coils: "Passives",
-    # ) -> None: ...
-    # def greens_with_plasma(
-    #     cls,
-    #     plasma: "Plasma",
-    # ) -> None: ...
-    # def calculate_sensor_values(
-    #     cls,
-    #     coils: "Coils",
-    #     passives: "Passives",
-    #     plasma: "Plasma",
-    # ) -> None: ...
+    def calculate_sensor_values(
+        cls,
+        plasma: "Plasma",
+    ) -> None: ...
 
 class EfitPolynomial(DataTreeAccessor):
     def __new__(

--- a/python/gsfit_rs/self_test.py
+++ b/python/gsfit_rs/self_test.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from gsfit_rs import BpProbes
 from gsfit_rs import Coils
+from gsfit_rs import Dialoop
 from gsfit_rs import EfitPolynomial
 from gsfit_rs import FluxLoops
 from gsfit_rs import Isoflux
@@ -80,6 +81,7 @@ def run() -> None:
     )
     isoflux = Isoflux()
     isoflux_boundary = IsofluxBoundary()
+    dialoop = Dialoop()
     stationary_point = StationaryPoint()
     stationary_point.add_sensor(
         name="magnetic_axis",
@@ -165,6 +167,7 @@ def run() -> None:
         isoflux_boundary=isoflux_boundary,
         pressure_sensors=pressure_sensors,
         stationary_point=stationary_point,
+        dialoop=dialoop,
         times_to_reconstruct=np.array([0.5]),
         n_iter_max=30,
         n_iter_min=1,

--- a/rust/gsfit_rs/src/grad_shafranov/epp_chi_sq_mag.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/epp_chi_sq_mag.rs
@@ -1,7 +1,7 @@
-use crate::sensors::{BpProbes, FluxLoops, RogowskiCoils};
+use crate::sensors::{BpProbes, Dialoop, FluxLoops, RogowskiCoils};
 use ndarray::{Array1, Array2};
 
-pub fn epp_chi_sq_mag(bp_probes: &BpProbes, flux_loops: &FluxLoops, rogowski_coils: &RogowskiCoils, n_time: usize) -> Array1<f64> {
+pub fn epp_chi_sq_mag(bp_probes: &BpProbes, flux_loops: &FluxLoops, rogowski_coils: &RogowskiCoils, dialoop: &Dialoop, n_time: usize) -> Array1<f64> {
     // Loop over all time-slices and calculate `chi_sq_mag`
     let mut chi_sq_mag_result: Array1<f64> = Array1::zeros(n_time);
 
@@ -60,6 +60,26 @@ pub fn epp_chi_sq_mag(bp_probes: &BpProbes, flux_loops: &FluxLoops, rogowski_coi
                     let sigma: f64 = rogowski_coils_expected_value[i_rogowski_coil] / rogowski_coils_weight[i_rogowski_coil];
                     chi_sq_mag_result[i_time] +=
                         (rogowski_coils_measured[(i_time, i_rogowski_coil)] - rogowski_coils_calculated[(i_time, i_rogowski_coil)]).powi(2) / sigma.powi(2);
+                }
+            }
+        }
+    }
+
+    let dialoop_names: Vec<String> = dialoop.results.keys();
+    let n_dialoop: usize = dialoop_names.len();
+    if n_dialoop > 0 {
+        let dialoop_measured: Array2<f64> = dialoop.results.get("*").get("b").get("measured").get("value").unwrap_array2();
+        let dialoop_calculated: Array2<f64> = dialoop.results.get("*").get("b").get("calculated").get("value").unwrap_array2();
+        let dialoop_weight: Array1<f64> = dialoop.results.get("*").get("fit_settings").get("weight").unwrap_array1();
+        let dialoop_expected_value: Array1<f64> = dialoop.results.get("*").get("fit_settings").get("expected_value").unwrap_array1();
+        let dialoop_include: Vec<bool> = dialoop.results.get("*").get("fit_settings").get("include").unwrap_vec_bool();
+        for i_time in 0..n_time {
+            // dialoop
+            for i_dialoop in 0..n_dialoop {
+                if dialoop_include[i_dialoop] {
+                    let sigma: f64 = dialoop_expected_value[i_dialoop] / dialoop_weight[i_dialoop];
+                    chi_sq_mag_result[i_time] +=
+                        (dialoop_measured[(i_time, i_dialoop)] - dialoop_calculated[(i_time, i_dialoop)]).powi(2) / sigma.powi(2);
                 }
             }
         }

--- a/rust/gsfit_rs/src/grad_shafranov/grad_shafranov_solver.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/grad_shafranov_solver.rs
@@ -3,7 +3,7 @@ use super::gs_solution::GsSolution;
 use crate::coils::Coils;
 use crate::passives::Passives;
 use crate::plasma::Plasma;
-use crate::sensors::{BpProbes, FluxLoops, Isoflux, IsofluxBoundary, Pressure, RogowskiCoils, SensorsDynamic, SensorsStatic, StationaryPoint};
+use crate::sensors::{BpProbes, Dialoop, FluxLoops, Isoflux, IsofluxBoundary, Pressure, RogowskiCoils, SensorsDynamic, SensorsStatic, StationaryPoint};
 use crate::source_functions::SourceFunctionTraits;
 use log::info; // use log::{debug, error, info};
 use ndarray::{Array1, Array2, s};
@@ -26,6 +26,7 @@ pub fn solve_grad_shafranov(
     mut isoflux_boundary: PyRefMut<IsofluxBoundary>,
     mut pressure_sensors: PyRefMut<Pressure>,
     mut stationary_point: PyRefMut<StationaryPoint>,
+    mut dialoop: PyRefMut<Dialoop>,
     times_to_reconstruct: PyReadonlyArray1<f64>,
     n_iter_max: usize,
     n_iter_min: usize,
@@ -69,6 +70,9 @@ pub fn solve_grad_shafranov(
 
     // Get static and dynamic data
     let coils_dynamic: Vec<SensorsDynamic> = coils.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
+    // TF rod current interpolated to `times_to_reconstruct`; used as f_vac = MU_0 * i_rod / (2 * PI)
+    // in the diamagnetic-loop constraint
+    let i_rod_vs_time: Array1<f64> = coils.results.get("tf").get("rod_i").get("measured").get("value").unwrap_array1();
     let (bp_probes_static, bp_probes_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
         bp_probes.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
     let (flux_loops_static, flux_loops_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
@@ -82,6 +86,8 @@ pub fn solve_grad_shafranov(
         pressure_sensors.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
     let (stationary_point_statics, stationary_point_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
         stationary_point.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
+    let (dialoop_statics, dialoop_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
+        dialoop.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
 
     // TODO: might be better to combine all sensors here, before passing to the solver
 
@@ -154,6 +160,8 @@ pub fn solve_grad_shafranov(
                 &bp_probes_dynamic[i_time],
                 &flux_loops_static[i_time],
                 &flux_loops_dynamic[i_time],
+                &dialoop_statics[i_time],
+                &dialoop_dynamic[i_time],
                 &rogowski_coils_static[i_time],
                 &rogowski_coils_dynamic[i_time],
                 &isoflux_statics[i_time],
@@ -168,6 +176,7 @@ pub fn solve_grad_shafranov(
                 n_iter_min,
                 n_iter_no_vertical_feedback,
                 gs_error,
+                i_rod_vs_time[i_time],
                 p_prime_source_function.clone(),
                 ff_prime_source_function.clone(),
                 passive_regularisations.clone(),
@@ -210,8 +219,10 @@ pub fn solve_grad_shafranov(
     if pressure_sensors.results.data.len() > 0 {
         pressure_sensors.calculate_sensor_values_rust(&plasma_owned);
     }
+    // The diamagnetic loop depends only on the toroidal flux function `f` (no Green's functions)
+    dialoop.calculate_sensor_values_rs(&plasma_owned);
 
     // Calculate chi_sq_mag for each time slice
-    let chi_mag: Array1<f64> = epp_chi_sq_mag(&bp_probes, &flux_loops, &rogowski_coils, n_time);
+    let chi_mag: Array1<f64> = epp_chi_sq_mag(&bp_probes, &flux_loops, &rogowski_coils, &dialoop, n_time);
     plasma.results.get_or_insert("global").insert("chi_mag", chi_mag);
 }

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -682,10 +682,16 @@ impl<'a> GsSolution<'a> {
             //     f = sqrt( f_vac^2 + 2*(psi_b - psi_a)*G ),   G = sum_i ff'_dof[i]*ff'_integral_i(psi_n)
             // and f_vac = R0*B_phi0 = MU_0*i_rod/(2*PI).
             //
-            // Linearising for small diamagnetism (|f - f_vac| << f_vac):
+            // Linearising for small diamagnetism (|f - f_vac| << |f_vac|):
             //     f - f_vac ~= (psi_b - psi_a) * G / f_vac
             // so the response is linear in the ff' degrees of freedom:
             //     T[i] = ((psi_b - psi_a) / f_vac) * dA * sum_grid [ mask * ff'_integral_i(psi_n) / R ]
+            //
+            // Note on sign: this linearisation divides by the *signed* f_vac, so it already
+            // preserves the correct sign for a negative TF rod current. Expanding the exact
+            // f = sign(f_vac)*sqrt(f_vac^2 + 2*(psi_b-psi_a)*G) for small G gives
+            // f - f_vac ~= (psi_b - psi_a)*G / f_vac, matching the term below without a separate
+            // sign() factor.
             let f_vac: f64 = MU_0 * self.i_rod / (2.0 * PI);
             let d_psi: f64 = self.psi_b - self.psi_a;
             for i_sensor in 0..n_dialoop {

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -29,6 +29,8 @@ pub struct GsSolution<'a> {
     bp_probes_dynamic: &'a SensorsDynamic,
     flux_loops_static: &'a SensorsStatic,
     flux_loops_dynamic: &'a SensorsDynamic,
+    dialoop_static: &'a SensorsStatic,
+    dialoop_dynamic: &'a SensorsDynamic,
     rogowski_coils_static: &'a SensorsStatic,
     rogowski_coils_dynamic: &'a SensorsDynamic,
     isoflux_static: &'a SensorsStatic,
@@ -43,6 +45,7 @@ pub struct GsSolution<'a> {
     n_iter_min: usize,
     n_iter_no_vertical_feedback: usize,
     gs_error_tolerence: f64,
+    i_rod: f64,
     // Results
     pub gs_error_calculated: f64,
     pub ff_prime_dof_values: Array1<f64>,
@@ -86,6 +89,8 @@ impl<'a> GsSolution<'a> {
         bp_probes_dynamic: &'a SensorsDynamic,
         flux_loops_static: &'a SensorsStatic,
         flux_loops_dynamic: &'a SensorsDynamic,
+        dialoop_static: &'a SensorsStatic,
+        dialoop_dynamic: &'a SensorsDynamic,
         rogowski_coils_static: &'a SensorsStatic,
         rogowski_coils_dynamic: &'a SensorsDynamic,
         isoflux_static: &'a SensorsStatic,
@@ -100,6 +105,7 @@ impl<'a> GsSolution<'a> {
         n_iter_min: usize,
         n_iter_no_vertical_feedback: usize,
         gs_error_tolerence: f64,
+        i_rod: f64,
         p_prime_source_function: Arc<dyn SourceFunctionTraits + Send + Sync>,
         ff_prime_source_function: Arc<dyn SourceFunctionTraits + Send + Sync>,
         passive_regularisations: Array2<f64>,
@@ -113,6 +119,8 @@ impl<'a> GsSolution<'a> {
             bp_probes_dynamic,
             flux_loops_static,
             flux_loops_dynamic,
+            dialoop_static,
+            dialoop_dynamic,
             rogowski_coils_static,
             rogowski_coils_dynamic,
             isoflux_static,
@@ -127,6 +135,7 @@ impl<'a> GsSolution<'a> {
             n_iter_min,
             n_iter_no_vertical_feedback,
             gs_error_tolerence,
+            i_rod,
             // Results
             gs_error_calculated: f64::NAN,
             ff_prime_dof_values: Array1::zeros(0),
@@ -207,6 +216,8 @@ impl<'a> GsSolution<'a> {
         let bp_probes_dynamic: &SensorsDynamic = self.bp_probes_dynamic;
         let flux_loops_static: &SensorsStatic = self.flux_loops_static;
         let flux_loops_dynamic: &SensorsDynamic = self.flux_loops_dynamic;
+        let dialoop_static: &SensorsStatic = self.dialoop_static;
+        let dialoop_dynamic: &SensorsDynamic = self.dialoop_dynamic;
         let rogowski_coils_static: &SensorsStatic = self.rogowski_coils_static;
         let rogowski_coils_dynamic: &SensorsDynamic = self.rogowski_coils_dynamic;
         let isoflux_static: &SensorsStatic = self.isoflux_static;
@@ -241,6 +252,7 @@ impl<'a> GsSolution<'a> {
         // Constraints
         let n_bp: usize = bp_probes_dynamic.measured.len();
         let n_fl: usize = flux_loops_dynamic.measured.len();
+        let n_dialoop: usize = dialoop_dynamic.measured.len();
         let n_rog: usize = rogowski_coils_dynamic.measured.len();
         let n_isoflux: usize = isoflux_dynamic.measured.len();
         let n_isoflux_boundary: usize = isoflux_boundary_dynamic.measured.len();
@@ -253,6 +265,7 @@ impl<'a> GsSolution<'a> {
         let n_delta_z_regularisation: usize = 0; // initially set to 0 because we don't have previous iteration
         let n_constraints: usize = n_bp
             + n_fl
+            + n_dialoop
             + n_rog
             + n_isoflux
             + n_isoflux_boundary
@@ -651,6 +664,44 @@ impl<'a> GsSolution<'a> {
                 // Store weights
                 constraint_weights[i_constraint] =
                     2.0 * PI * flux_loops_static.fit_settings_weight[i_sensor] / flux_loops_static.fit_settings_expected_value[i_sensor];
+
+                // Setup indexer for next sensor or constraint
+                i_constraint += 1;
+            }
+
+            // Add dialoop (diamagnetic flux loop) to the fitting matrix.
+            //
+            // The diamagnetic loop responds to the toroidal flux function `f` (the poloidal-current
+            // function), which depends only on the ff' source function — NOT on the toroidal
+            // currents. The Green's tables relate toroidal currents to psi/B_p, so the dialoop uses
+            // NO Green's functions, and no p', passive, coil or vertical-stabilisation terms.
+            //
+            // The diamagnetic flux is (Moret Eq. 41):
+            //     Phi_t = integral( (f - f_vac) / R ) dA          (over the plasma mask)
+            // where, as in `epp_bt_2d`, `f` is reconstructed from the ff' source function:
+            //     f = sqrt( f_vac^2 + 2*(psi_b - psi_a)*G ),   G = sum_i ff'_dof[i]*ff'_integral_i(psi_n)
+            // and f_vac = R0*B_phi0 = MU_0*i_rod/(2*PI).
+            //
+            // Linearising for small diamagnetism (|f - f_vac| << f_vac):
+            //     f - f_vac ~= (psi_b - psi_a) * G / f_vac
+            // so the response is linear in the ff' degrees of freedom:
+            //     T[i] = ((psi_b - psi_a) / f_vac) * dA * sum_grid [ mask * ff'_integral_i(psi_n) / R ]
+            let f_vac: f64 = MU_0 * self.i_rod / (2.0 * PI);
+            let d_psi: f64 = self.psi_b - self.psi_a;
+            for i_sensor in 0..n_dialoop {
+                // ff_prime degrees of freedom only (no p', no passives, no coils, no Green's)
+                for i_ff_prime_dof in 0..n_ff_prime_dof {
+                    let ff_prime_integral: Array1<f64> = ff_prime_source_function.source_function_integral_single_dof(&psi_n_flat, i_ff_prime_dof);
+                    let integrand: Array1<f64> = &mask_flat * &ff_prime_integral / &flat_r;
+                    fitting_matrix[(i_constraint, n_p_prime_dof + i_ff_prime_dof)] = (d_psi / f_vac) * d_area * integrand.sum();
+                }
+
+                // Store sensor value
+                s_measured[i_constraint] = dialoop_dynamic.measured[i_sensor];
+
+                // Store weights
+                constraint_weights[i_constraint] =
+                    dialoop_static.fit_settings_weight[i_sensor] / dialoop_static.fit_settings_expected_value[i_sensor];
 
                 // Setup indexer for next sensor or constraint
                 i_constraint += 1;

--- a/rust/gsfit_rs/src/plasma.rs
+++ b/rust/gsfit_rs/src/plasma.rs
@@ -1462,28 +1462,43 @@ fn epp_bt_2d(gs_solution: &GsSolution, r: &Array1<f64>, z: &Array1<f64>, i_rod: 
         bt_vac_2d_now.slice_mut(s![i_z, ..]).assign(&bt_vac_vs_r);
     }
 
+    // ψ_N = (ψ_A − ψ) / (ψ_A − ψ_B), so:
+    //   ψ = ψ_A − (ψ_A − ψ_B)·ψ_N
+    //   dψ/dψ_N = ψ_B − ψ_A
+    //
     // Outside the plasma:
-    // BT(R) = i_rod * MU_0 / (2 * PI * R)
+    //   B_T(R) = μ₀·I_rod / (2π·R)
+    //
     // Inside the plasma:
-    // BT(R) = f/R
-    // where `f` comes from the integral of `ff_prime`
-    // f = 1/2*int(ff_prime) + constant_of_integration
-    // `constant_of_integration` set so that BT at plasma boundary = vacuum BT
-    let f_boundary: f64 = i_rod * MU_0 / (2.0 * PI);
+    //   B_T(R) = f(ψ) / R
+    // where f is defined by the identity:
+    //   f²/2 = ∫_{ψ_B}^{ψ} ff′(ψ′) dψ′ + f_vac²/2
+    // with f_vac = μ₀·I_rod / (2π), which ensures f = f_vac at the boundary (ψ_N = 1).
+    //
+    // Changing integration variable to ψ_N:
+    //   f²/2 = (ψ_B − ψ_A) · ∫_1^{ψ_N} ff′(ψ_N′) dψ_N′ + f_vac²/2
+    //
+    // Rearranging:
+    //   f² = f_vac² + 2·(ψ_B − ψ_A) · ∫_1^{ψ_N} ff′(ψ_N′) dψ_N′
+    //   f  = √( f_vac² + 2·(ψ_B − ψ_A) · ∫_1^{ψ_N} ff′(ψ_N′) dψ_N′ )
+    //
+    // Note: `source_function_integral` integrates from 1 to ψ_N, so it is zero at ψ_N = 1
+    // and we recover f = f_vac at the boundary as required.
+    let f_vac: f64 = i_rod * MU_0 / (2.0 * PI);
 
-    // d(psi)/d(psi_n)
-    let d_psi_d_psi_n: f64 = 1.0 / (psi_b - psi_a);
+    // dψ/dψ_N = ψ_B − ψ_A
+    let d_psi_d_psi_n: f64 = psi_b - psi_a;
 
     for i_z in 0..n_z {
         for i_r in 0..n_r {
             if mask[(i_z, i_r)] > 0.99 {
-                // Integrate the source function
-                let f_unnormalise: f64 = gs_solution
+                // ∫_1^{ψ_N} ff′(ψ_N′) dψ_N′
+                let ff_prime_integral: f64 = gs_solution
                     .ff_prime_source_function
                     .source_function_integral(&Array1::from_vec(vec![psi_n_2d[(i_z, i_r)]]), &ff_prime_dof_values)[0];
 
-                // Calculate the poloidal flux function, f
-                let f_at_this_rz: f64 = f_unnormalise / d_psi_d_psi_n + f_boundary;
+                // f = √( f_vac² + 2·(dψ/dψ_N)·∫_1^{ψ_N} ff′ dψ_N′ )
+                let f_at_this_rz: f64 = (f_vac * f_vac + 2.0 * d_psi_d_psi_n * ff_prime_integral).sqrt();
 
                 // Toroidal field
                 bt_2d_now[(i_z, i_r)] = f_at_this_rz / r[i_r];
@@ -1506,23 +1521,28 @@ fn epp_f_profile(gs_solution: &GsSolution, psi_n: &Array1<f64>, psi_a: f64, psi_
 
     let ff_prime_dof_values: Array1<f64> = gs_solution.ff_prime_dof_values.to_owned();
 
-    // f(psi_n) = R * BT(R)
-    // BT(R) = i_rod * MU_0 / (2 * PI * R)
-    // f_boundary = i_rod * MU_0 / (2 * PI)
-    // Constant of integration set so that BT at plasma boundary = vacuum BT
-    let f_boundary: f64 = i_rod * MU_0 / (2.0 * PI);
+    // f(ψ) = R·B_T(R) is the poloidal-current function.
+    // It satisfies:
+    //   f²/2 = ∫_{ψ_B}^{ψ} ff′(ψ′) dψ′ + f_vac²/2
+    // where f_vac = μ₀·I_rod / (2π) ensures f = f_vac at the boundary (ψ_N = 1).
+    //
+    // ψ_N = (ψ_A − ψ) / (ψ_A − ψ_B), so dψ/dψ_N = ψ_B − ψ_A.
+    // Changing variable to ψ_N:
+    //   f² = f_vac² + 2·(ψ_B − ψ_A) · ∫_1^{ψ_N} ff′(ψ_N′) dψ_N′
+    //   f  = √( f_vac² + 2·(dψ/dψ_N) · ∫_1^{ψ_N} ff′(ψ_N′) dψ_N′ )
+    let f_vac: f64 = i_rod * MU_0 / (2.0 * PI);
 
-    // d(psi)/d(psi_n)
-    let d_psi_d_psi_n: f64 = 1.0 / (psi_b - psi_a);
+    // dψ/dψ_N = ψ_B − ψ_A
+    let d_psi_d_psi_n: f64 = psi_b - psi_a;
 
     for i_psi_n in 0..n_psi_n {
-        // Integrate the source function
-        let f_local: f64 = gs_solution
+        // ∫_1^{ψ_N} ff′(ψ_N′) dψ_N′
+        let ff_prime_integral: f64 = gs_solution
             .ff_prime_source_function
             .source_function_integral(&Array1::from_vec(vec![psi_n[i_psi_n]]), &ff_prime_dof_values)[0];
 
-        // Apply the mask, and store pressure
-        f_profile[i_psi_n] = f_local / d_psi_d_psi_n + f_boundary;
+        // f = √( f_vac² + 2·(dψ/dψ_N)·∫_1^{ψ_N} ff′ dψ_N′ )
+        f_profile[i_psi_n] = (f_vac * f_vac + 2.0 * d_psi_d_psi_n * ff_prime_integral).sqrt();
     }
 
     return f_profile;
@@ -1771,8 +1791,9 @@ fn epp_mid_plane_p_profile(
 
     let p_prime_dof_values: Array1<f64> = gs_solution.p_prime_dof_values.to_owned();
 
-    // d(psi)/d(psi_n)
-    let d_psi_d_psi_n: f64 = 1.0 / (psi_b - psi_a);
+    // p = (dψ/dψ_N) · ∫_1^{ψ_N} p′(ψ_N′) dψ_N′,  where  dψ/dψ_N = ψ_B − ψ_A
+    // See epp_p_profile for the full derivation.
+    let d_psi_d_psi_n: f64 = psi_b - psi_a;
 
     // TODO: change this to a slice
     for i_r in 0..n_r {
@@ -1783,7 +1804,7 @@ fn epp_mid_plane_p_profile(
             .source_function_integral(&Array1::from_vec(vec![psi_n_here]), &p_prime_dof_values)[0];
 
         // Apply the mask, and store pressure
-        p_profile[i_r] = pressure_local * mask_2d[(i_z_centre, i_r)] / d_psi_d_psi_n;
+        p_profile[i_r] = pressure_local * mask_2d[(i_z_centre, i_r)] * d_psi_d_psi_n;
     }
 
     return p_profile;
@@ -1802,8 +1823,9 @@ fn epp_p_2d(gs_solution: &GsSolution, r: &Array1<f64>, z: &Array1<f64>) -> Array
     let psi_a: f64 = gs_solution.psi_a;
     let psi_b: f64 = gs_solution.psi_b;
 
-    // d(psi)/d(psi_n)
-    let d_psi_d_psi_n: f64 = 1.0 / (psi_b - psi_a);
+    // p = (dψ/dψ_N) · ∫_1^{ψ_N} p′(ψ_N′) dψ_N′,  where  dψ/dψ_N = ψ_B − ψ_A
+    // See epp_p_profile for the full derivation.
+    let d_psi_d_psi_n: f64 = psi_b - psi_a;
 
     let p_prime_dof_values: Array1<f64> = gs_solution.p_prime_dof_values.to_owned();
 
@@ -1817,7 +1839,7 @@ fn epp_p_2d(gs_solution: &GsSolution, r: &Array1<f64>, z: &Array1<f64>) -> Array
             let pressure_local: f64 = pressure_local_ndarray[0];
 
             // Apply the mask, and store pressure
-            p_2d[(i_z, i_r)] = pressure_local * mask_2d[(i_z, i_r)] / d_psi_d_psi_n;
+            p_2d[(i_z, i_r)] = pressure_local * mask_2d[(i_z, i_r)] * d_psi_d_psi_n;
         }
     }
 
@@ -1851,11 +1873,21 @@ fn epp_hessian_matrix(gs_solution: &GsSolution, r: &Array1<f64>, z: &Array1<f64>
 fn epp_p_profile(gs_solution: &GsSolution, psi_n: &Array1<f64>, psi_a: f64, psi_b: f64) -> Array1<f64> {
     let p_prime_dof_values: Array1<f64> = gs_solution.p_prime_dof_values.to_owned();
 
-    // d(psi)/d(psi_n)
-    let d_psi_d_psi_n: f64 = 1.0 / (psi_b - psi_a);
+    // ψ_N = (ψ_A − ψ) / (ψ_A − ψ_B), so:
+    //   ψ = ψ_A − (ψ_A − ψ_B)·ψ_N
+    //   dψ/dψ_N = ψ_B − ψ_A
+    //
+    // Pressure is zero at the boundary (ψ_N = 1) and satisfies:
+    //   p(ψ) = ∫_{ψ_B}^{ψ} p′(ψ′) dψ′
+    //        = ∫_1^{ψ_N} p′(ψ_N′) · (dψ/dψ_N) dψ_N′
+    //        = (ψ_B − ψ_A) · ∫_1^{ψ_N} p′(ψ_N′) dψ_N′
+    // Note: `source_function_integral` integrates from 1 to ψ_N and is zero at ψ_N = 1.
 
-    // Integrate the source function
-    let p_profile: Array1<f64> = gs_solution.p_prime_source_function.source_function_integral(psi_n, &p_prime_dof_values) / d_psi_d_psi_n;
+    // dψ/dψ_N = ψ_B − ψ_A
+    let d_psi_d_psi_n: f64 = psi_b - psi_a;
+
+    // p = (dψ/dψ_N) · ∫_1^{ψ_N} p′(ψ_N′) dψ_N′
+    let p_profile: Array1<f64> = gs_solution.p_prime_source_function.source_function_integral(psi_n, &p_prime_dof_values) * d_psi_d_psi_n;
 
     p_profile
 }

--- a/rust/gsfit_rs/src/plasma.rs
+++ b/rust/gsfit_rs/src/plasma.rs
@@ -874,8 +874,8 @@ impl Plasma {
         // Magnetic axis
         let mut r_mag: Array1<f64> = Array1::from_elem(n_time, f64::NAN);
         let mut z_mag: Array1<f64> = Array1::from_elem(n_time, f64::NAN);
-        // Total toroidal flux
-        let mut flux_tor: Array1<f64> = Array1::from_elem(n_time, f64::NAN);
+        // Diamagnetic toroidal flux
+        let mut flux_dia: Array1<f64> = Array1::from_elem(n_time, f64::NAN);
 
         let mut xpt_diverted: Vec<bool> = Vec::with_capacity(n_time);
 
@@ -1109,7 +1109,7 @@ impl Plasma {
             let f_profile_vacuum: Array1<f64> = 0.0 * &f_profile_local + MU_0 * i_rod[i_time] / (2.0 * PI);
             let q_profile_vacuum: Array1<f64> = epp_q_profile(&gs_solutions[i_time], &flux_surfaces, &f_profile_vacuum, &r, &z);
             let flux_tor_profile_vacuum: Array1<f64> = epp_flux_toroidal_profile(&q_profile_vacuum, &psi_profile_this_time);
-            flux_tor[i_time] = flux_tor_profile_this_time_slice.last().unwrap().to_owned() - flux_tor_profile_vacuum.last().unwrap().to_owned();
+            flux_dia[i_time] = flux_tor_profile_this_time_slice.last().unwrap().to_owned() - flux_tor_profile_vacuum.last().unwrap().to_owned();
 
             let rho_tor_profile_this_time_slice: Array1<f64> = epp_rho_tor_profile(&flux_tor_profile_this_time_slice);
             rho_tor_profile.slice_mut(s![i_time, ..]).assign(&rho_tor_profile_this_time_slice);
@@ -1243,7 +1243,7 @@ impl Plasma {
         self.results.get_or_insert("global").insert("z_geo", z_geo);
         self.results.get_or_insert("global").insert("r_mag", r_mag);
         self.results.get_or_insert("global").insert("z_mag", z_mag);
-        self.results.get_or_insert("global").insert("phi_dia", flux_tor);
+        self.results.get_or_insert("global").insert("phi_dia", flux_dia);
         self.results.get_or_insert("global").insert("n_iter", n_iter);
         self.results.get_or_insert("global").insert("plasma_volume", plasma_volume);
         self.results.get_or_insert("global").insert("v_loop", v_loop);

--- a/rust/gsfit_rs/src/plasma.rs
+++ b/rust/gsfit_rs/src/plasma.rs
@@ -1497,8 +1497,12 @@ fn epp_bt_2d(gs_solution: &GsSolution, r: &Array1<f64>, z: &Array1<f64>, i_rod: 
                     .ff_prime_source_function
                     .source_function_integral(&Array1::from_vec(vec![psi_n_2d[(i_z, i_r)]]), &ff_prime_dof_values)[0];
 
-                // f = √( f_vac² + 2·(dψ/dψ_N)·∫_1^{ψ_N} ff′ dψ_N′ )
-                let f_at_this_rz: f64 = (f_vac * f_vac + 2.0 * d_psi_d_psi_n * ff_prime_integral).sqrt();
+                // f = sign(f_vac)·√( f_vac² + 2·(dψ/dψ_N)·∫_1^{ψ_N} ff′ dψ_N′ )
+                // The sign of f_vac must be preserved so that a negative TF rod current
+                // (f_vac < 0) yields a negative f inside the plasma, matching the vacuum
+                // boundary condition f(ψ_N = 1) = f_vac.
+                let f_sign: f64 = if f_vac >= 0.0 { 1.0 } else { -1.0 };
+                let f_at_this_rz: f64 = f_sign * (f_vac * f_vac + 2.0 * d_psi_d_psi_n * ff_prime_integral).sqrt();
 
                 // Toroidal field
                 bt_2d_now[(i_z, i_r)] = f_at_this_rz / r[i_r];
@@ -1541,8 +1545,12 @@ fn epp_f_profile(gs_solution: &GsSolution, psi_n: &Array1<f64>, psi_a: f64, psi_
             .ff_prime_source_function
             .source_function_integral(&Array1::from_vec(vec![psi_n[i_psi_n]]), &ff_prime_dof_values)[0];
 
-        // f = √( f_vac² + 2·(dψ/dψ_N)·∫_1^{ψ_N} ff′ dψ_N′ )
-        f_profile[i_psi_n] = (f_vac * f_vac + 2.0 * d_psi_d_psi_n * ff_prime_integral).sqrt();
+        // f = sign(f_vac)·√( f_vac² + 2·(dψ/dψ_N)·∫_1^{ψ_N} ff′ dψ_N′ )
+        // The sign of f_vac must be preserved so that a negative TF rod current
+        // (f_vac < 0) yields a negative f, matching the vacuum boundary condition
+        // f(ψ_N = 1) = f_vac.
+        let f_sign: f64 = if f_vac >= 0.0 { 1.0 } else { -1.0 };
+        f_profile[i_psi_n] = f_sign * (f_vac * f_vac + 2.0 * d_psi_d_psi_n * ff_prime_integral).sqrt();
     }
 
     return f_profile;

--- a/rust/gsfit_rs/src/sensors/dialoop.rs
+++ b/rust/gsfit_rs/src/sensors/dialoop.rs
@@ -1,7 +1,5 @@
 use crate::Plasma;
-use crate::coils::Coils;
-use crate::passives::Passives;
-use crate::sensors::static_and_dynamic_data_types::{SensorsDynamic, SensorsStatic};
+use crate::sensors::static_and_dynamic_data_types::{SensorsDynamic, SensorsStatic, create_empty_sensor_data};
 use data_tree::{AddDataTreeGetters, DataTree, DataTreeAccumulator};
 use ndarray::{Array1, Array2, Array3, Axis, s};
 use numpy::IntoPyArray;
@@ -10,6 +8,9 @@ use numpy::borrow::PyReadonlyArray1;
 use numpy::{PyArray1, PyArray2, PyArray3};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
+use std::f64::consts::PI;
+
+const MU_0: f64 = physical_constants::VACUUM_MAG_PERMEABILITY;
 
 #[derive(Clone, AddDataTreeGetters)]
 #[pyclass(module = "gsfit_rs", skip_from_py_object)]
@@ -23,7 +24,34 @@ impl Default for Dialoop {
     }
 }
 
-/// Python accessible methods
+/// Diamagnetic flux loop ("DIALOOP").
+///
+/// # Physics
+///
+/// The diamagnetic flux loop measures the difference between the actual toroidal flux and the
+/// vacuum toroidal field, integrated over the poloidal cross-section (Moret Eq. 41):
+///
+/// ```text
+///     Phi_t = integral( (f - f_vac) / R ) dR dZ
+/// ```
+///
+/// where `f = R * B_phi` is the toroidal flux function (the poloidal-current function) and
+/// `f_vac = R0 * B_phi0 = MU_0 * i_rod / (2 * PI)` is the vacuum value. Outside the plasma
+/// `f = f_vac`, so the integrand is zero there and the integral is taken over the plasma mask.
+///
+/// Crucially, `f` depends on the **poloidal** currents (the ff' source function), *not* on the
+/// toroidal currents. The Green's tables in gsfit relate toroidal currents to `psi`/`B_p`, so the
+/// diamagnetic loop deliberately uses **no Green's functions** (no coils, no passives, no plasma
+/// grid Green's, no vertical-stabilisation terms).
+///
+/// In gsfit, `f` is reconstructed from the ff' source function exactly as in `epp_bt_2d`:
+///
+/// ```text
+///     f = sqrt( f_vac^2 + 2 * (psi_b - psi_a) * G(psi_n) )
+/// ```
+///
+/// where `G(psi_n) = sum_i ff'_dof[i] * ff'_integral_i(psi_n)` is the integral of the ff' source
+/// function.
 #[pymethods]
 impl Dialoop {
     #[new]
@@ -31,29 +59,16 @@ impl Dialoop {
         Self { results: DataTree::new() }
     }
 
-    /// Data structure:
+    /// Add a single diamagnetic loop sensor.
     ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// [probe_name]["b"]["calculated"]                                 = Array1<f64>;  shape=[n_time]
-    /// [probe_name]["b"]["measured"]                                   = Array1<f64>;  shape=[n_time]
-    /// [probe_name]["fit_settings"]["comment"]                         = str
-    /// [probe_name]["fit_settings"]["expected_value"]                  = f64
-    /// [probe_name]["fit_settings"]["include"]                         = bool
-    /// [probe_name]["fit_settings"]["weight"]                          = f64
-    /// [probe_name]["geometry"]["angle_pol"]                           = f64
-    /// [probe_name]["geometry"]["r"]                                   = f64
-    /// [probe_name]["geometry"]["z"]                                   = f64
-    /// [probe_name]["greens"]["d_plasma_d_z"]                          = Array1;  shape=[n_z * n_r]
-    /// [probe_name]["greens"]["passives"][passive_name][dof_name]      = f64
-    /// [probe_name]["greens"]["pf"][pf_name]                           = f64
-    /// [probe_name]["greens"]["plasma"]                                = Array1;  shape=[n_z * n_r]
-    /// ```
+    /// The loop path `(r, z)` is stored for reference only; the diamagnetic flux is an integral
+    /// over the poloidal cross-section enclosed by the loop and does not use the path directly.
     #[allow(clippy::too_many_arguments)]
     pub fn add_sensor(
         &mut self,
         name: &str,
+        r: PyReadonlyArray1<f64>,
+        z: PyReadonlyArray1<f64>,
         fit_settings_comment: String,
         fit_settings_expected_value: f64,
         fit_settings_include: bool,
@@ -61,191 +76,32 @@ impl Dialoop {
         time: PyReadonlyArray1<f64>,
         measured: PyReadonlyArray1<f64>,
     ) {
-        // Convert into Rust data types
-        let time_ndarray: Array1<f64> = time.to_owned_array();
-        let measured_ndarray: Array1<f64> = measured.to_owned_array();
+        // Loop-path geometry (stored for reference only)
+        self.results.get_or_insert(name).get_or_insert("geometry").insert("r_path", r.to_owned_array());
+        self.results.get_or_insert(name).get_or_insert("geometry").insert("z_path", z.to_owned_array());
 
         // Fit settings
-        self.results
-            .get_or_insert(name)
-            .get_or_insert("fit_settings")
-            .insert("comment", fit_settings_comment);
+        self.results.get_or_insert(name).get_or_insert("fit_settings").insert("comment", fit_settings_comment);
         self.results
             .get_or_insert(name)
             .get_or_insert("fit_settings")
             .insert("expected_value", fit_settings_expected_value);
-        self.results
-            .get_or_insert(name)
-            .get_or_insert("fit_settings")
-            .insert("include", fit_settings_include);
-        self.results
-            .get_or_insert(name)
-            .get_or_insert("fit_settings")
-            .insert("weight", fit_settings_weight);
+        self.results.get_or_insert(name).get_or_insert("fit_settings").insert("include", fit_settings_include);
+        self.results.get_or_insert(name).get_or_insert("fit_settings").insert("weight", fit_settings_weight);
 
         // Measurements
-        self.results.get_or_insert(name).get_or_insert("b").insert("time_experimental", time_ndarray);
+        self.results.get_or_insert(name).get_or_insert("b").get_or_insert("experimental").insert("time", time.to_owned_array());
         self.results
             .get_or_insert(name)
             .get_or_insert("b")
-            .insert("measured_experimental", measured_ndarray);
-        // I want to store both the full time and the down sampled...
+            .get_or_insert("experimental")
+            .insert("value", measured.to_owned_array());
     }
 
-    // ///
-    // pub fn greens_with_coils(&mut self, coils: PyRef<Coils>) {
-    //     // Change Python type into Rust
-    //     let coils_local: &Coils = &coils;
-
-    //     for sensor_name in self.results.keys() {
-    //         let sensor_angle_pol: f64 = self.results.get(&sensor_name).get("geometry").get("angle_pol").unwrap_f64();
-    //         let sensor_r: f64 = self.results.get(&sensor_name).get("geometry").get("r").unwrap_f64();
-    //         let sensor_z: f64 = self.results.get(&sensor_name).get("geometry").get("z").unwrap_f64();
-
-    //         for pf_coil_name in coils_local.results.get("pf").keys() {
-    //             let coil_r: Array1<f64> = coils.results.get("pf").get(&pf_coil_name).get("geometry").get("r").unwrap_array1();
-    //             let coil_z: Array1<f64> = coils.results.get("pf").get(&pf_coil_name).get("geometry").get("z").unwrap_array1();
-
-    //             let (g_br_full, g_bz_full): (Array2<f64>, Array2<f64>) = greens_b(
-    //                 Array1::from_vec(vec![sensor_r]),
-    //                 Array1::from_vec(vec![sensor_z]),
-    //                 coil_r.clone(),
-    //                 coil_z.clone(),
-    //             );
-
-    //             // Sum over all the current sources
-    //             let g_br: f64 = g_br_full.sum();
-    //             let g_bz: f64 = g_bz_full.sum();
-
-    //             // Sensors Green's function
-    //             let g = g_br * sensor_angle_pol.cos() + g_bz * sensor_angle_pol.sin();
-
-    //             // Store
-    //             self.results
-    //                 .get_or_insert(&sensor_name)
-    //                 .get_or_insert("greens")
-    //                 .get_or_insert("pf")
-    //                 .insert(&pf_coil_name, g);
-    //         }
-    //     }
-    // }
-
-    // ///
-    // pub fn greens_with_passives(&mut self, passives: PyRef<Passives>) {
-    //     // Change Python type into Rust
-    //     let passives_local: &Passives = &passives;
-
-    //     for sensor_name in self.results.keys() {
-    //         let sensor_r: f64 = self.results.get(&sensor_name).get("geometry").get("r").unwrap_f64();
-    //         let sensor_z: f64 = self.results.get(&sensor_name).get("geometry").get("z").unwrap_f64();
-    //         let sensor_angle_pol: f64 = self.results.get(&sensor_name).get("geometry").get("angle_pol").unwrap_f64();
-
-    //         // Calculate Greens with each passive degree of freedom
-    //         for passive_name in passives_local.results.keys() {
-    //             let _tmp: DataTreeAccumulator<'_> = passives_local.results.get(&passive_name).get("dof");
-    //             let dof_names: Vec<String> = _tmp.keys();
-    //             let passive_r: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("r").unwrap_array1();
-    //             let passive_z: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("z").unwrap_array1();
-
-    //             for dof_name in dof_names {
-    //                 let (g_br_full, g_bz_full): (Array2<f64>, Array2<f64>) = greens_b(
-    //                     Array1::from_vec(vec![sensor_r]), // by convention (r, z) are "sensors"
-    //                     Array1::from_vec(vec![sensor_z]),
-    //                     passive_r.clone(), // by convention (r_prime, z_prime) are "current sources"
-    //                     passive_z.clone(),
-    //                 );
-
-    //                 // Current distribution
-    //                 let current_distribution: Array1<f64> = passives
-    //                     .results
-    //                     .get(&passive_name)
-    //                     .get("dof")
-    //                     .get(&dof_name)
-    //                     .get("current_distribution")
-    //                     .unwrap_array1();
-
-    //                 let g_br_with_dof_full: Array2<f64> = g_br_full * &current_distribution; // shape = [n_r * n_z, n_filament]
-    //                 let g_bz_with_dof_full: Array2<f64> = g_bz_full * current_distribution; // shape = [n_r * n_z, n_filament]
-
-    //                 // Sum over all filaments
-    //                 let g_br: f64 = g_br_with_dof_full.sum(); // shape = [n_r * n_z]
-    //                 let g_bz: f64 = g_bz_with_dof_full.sum(); // shape = [n_r * n_z]
-
-    //                 // Calculate Green's function
-    //                 let g: f64 = g_br * sensor_angle_pol.cos() + g_bz * sensor_angle_pol.sin();
-
-    //                 // Store
-    //                 self.results
-    //                     .get_or_insert(&sensor_name)
-    //                     .get_or_insert("greens")
-    //                     .get_or_insert("passives")
-    //                     .get_or_insert(&passive_name)
-    //                     .insert(&dof_name, g);
-    //             }
-    //         }
-    //     }
-    // }
-
-    // ///
-    // pub fn greens_with_plasma(&mut self, plasma: PyRef<Plasma>) {
-    //     // Change Python type into Rust
-    //     let plasma_local: &Plasma = &plasma;
-
-    //     let plasma_r: Array1<f64> = plasma_local.results.get("grid").get("flat").get("r").unwrap_array1();
-    //     let plasma_z: Array1<f64> = plasma_local.results.get("grid").get("flat").get("z").unwrap_array1();
-
-    //     for sensor_name in self.results.keys() {
-    //         // Get variables out of self
-    //         let sensor_angle_pol: f64 = self.results.get(&sensor_name).get("geometry").get("angle_pol").unwrap_f64();
-    //         let sensor_r: f64 = self.results.get(&sensor_name).get("geometry").get("r").unwrap_f64();
-    //         let sensor_z: f64 = self.results.get(&sensor_name).get("geometry").get("z").unwrap_f64();
-
-    //         let (g_br_full, g_bz_full): (Array2<f64>, Array2<f64>) = greens_b(
-    //             Array1::from_vec(vec![sensor_r]), // sensor
-    //             Array1::from_vec(vec![sensor_z]),
-    //             plasma_r.clone(), // current source
-    //             plasma_z.clone(),
-    //         );
-
-    //         let g_br: Array1<f64> = g_br_full.sum_axis(Axis(0)); // g_br_full.shape = [1, n_z * n_r];  g_br.shape = [n_z * n_r]
-    //         let g_bz: Array1<f64> = g_bz_full.sum_axis(Axis(0));
-
-    //         // Sensors Green's function
-    //         let g_with_plasma: Array1<f64> = g_br * sensor_angle_pol.cos() + g_bz * sensor_angle_pol.sin();
-
-    //         // Store
-    //         self.results.get_or_insert(&sensor_name).get_or_insert("greens").insert("plasma", g_with_plasma);
-
-    //         // Vertical stability
-    //         let (g_d_plasma_br_d_z_full, g_d_plasma_bz_d_z_full): (Array2<f64>, Array2<f64>) = greens_d_b_dz(
-    //             Array1::from_vec(vec![sensor_r]), // sensor
-    //             Array1::from_vec(vec![sensor_z]),
-    //             plasma_r.clone(), // current source
-    //             plasma_z.clone(),
-    //         );
-
-    //         let g_d_plasma_br_d_z: Array1<f64> = g_d_plasma_br_d_z_full.sum_axis(Axis(0)); // g_br_full.shape = [1, n_z * n_r];  g_br.shape = [n_z * n_r]
-    //         let g_d_plasma_bz_d_z: Array1<f64> = g_d_plasma_bz_d_z_full.sum_axis(Axis(0));
-
-    //         // Sensors Green's function
-    //         let g_d_plasma_d_z: Array1<f64> = g_d_plasma_br_d_z * sensor_angle_pol.cos() + g_d_plasma_bz_d_z * sensor_angle_pol.sin();
-
-    //         // Store
-    //         // TODO: should I reshape to Array2 [n_z, n_r] ????
-    //         self.results
-    //             .get_or_insert(&sensor_name)
-    //             .get_or_insert("greens")
-    //             .insert("d_plasma_d_z", g_d_plasma_d_z);
-    //     }
-    // }
-
-    /// Calculate the sensor values
+    /// Calculate the sensor values from a reconstructed `Plasma` (Python entry-point).
     pub fn calculate_sensor_values(&mut self, plasma: PyRef<Plasma>) {
-        // Convert Python types into Rust
         let plasma_rs: &Plasma = &plasma;
-
-        // Run the Rust method
-        self.calculate_sensor_values_rust(plasma_rs);
+        self.calculate_sensor_values_rs(plasma_rs);
     }
 
     /// Print to screen, to be used within Python
@@ -256,9 +112,8 @@ impl Dialoop {
         string_output += &format!("║  {:<74} ║\n", "<gsfit_rs.Dialoop>");
         string_output += &format!("║  {:<74} ║\n", version);
 
-        // n_sensors = self.results
         let n_sensors: usize = self.results.keys().len();
-        string_output += &format!("║  {:<74} ║\n", format!("n_sensors = {}", n_sensors.to_string()));
+        string_output += &format!("║  {:<74} ║\n", format!("n_sensors = {}", n_sensors));
 
         string_output.push_str("╚═════════════════════════════════════════════════════════════════════════════╝");
 
@@ -268,141 +123,159 @@ impl Dialoop {
 
 // Rust only methods
 impl Dialoop {
-    // /// This splits the Dialoop into:
-    // /// 1.) Static (non time-dependent) object. Note, it is here that the sensors are down-selected, based on ["fit_settings"]["include"]
-    // /// 2.) A Vec of time-dependent ojbects. Note, the length of the Vec is the number of time-slices we want to reconstruct
-    // pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (SensorsStatic, Vec<SensorsDynamic>) {
-    //     // Vector of boolean's to say if we use the sensor or not
-    //     let include: Vec<bool> = self.results.get("*").get("fit_settings").get("include").unwrap_vec_bool();
+    /// Split the `Dialoop` into:
+    /// 1.) Static (non time-dependent) data. Sensors are down-selected here based on `["fit_settings"]["include"]`.
+    /// 2.) A `Vec` of time-dependent objects (one per time-slice we want to reconstruct).
+    ///
+    /// Diamagnetic loops do not use Green's functions: the response is computed directly from the
+    /// ff' source function inside the GS solver (see `gs_solution.rs`). The Green's arrays below are
+    /// therefore left empty.
+    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (Vec<SensorsStatic>, Vec<SensorsDynamic>) {
+        let n_time: usize = times_to_reconstruct.len();
 
-    //     // Convert from boolean to indices
-    //     let include_indices: Vec<usize> = include
-    //         .iter()
-    //         .enumerate()
-    //         .filter(|(_, &include)| include) // Filter for `true` values
-    //         .map(|(i, _)| i) // Extract the indices
-    //         .collect(); // Collect into a Vec
+        // Vector of boolean's to say if we use the sensor or not
+        let include: Vec<bool> = self.results.get("*").get("fit_settings").get("include").unwrap_vec_bool();
 
-    //     // Sensor names
-    //     let sensor_names_all: Vec<String> = self.results.keys();
-    //     let n_sensors_all: usize = sensor_names_all.len();
-    //     // Down select sensor names
-    //     let sensor_names: Vec<String> = include_indices.iter().map(|&index| sensor_names_all[index].clone()).collect();
-    //     let n_sensors: usize = sensor_names.len();
+        // Convert from boolean to indices
+        let include_indices: Vec<usize> = include
+            .iter()
+            .enumerate()
+            .filter(|(_, include)| **include)
+            .map(|(i, _)| i)
+            .collect();
 
-    //     // Fit settings
-    //     // Weight
-    //     let fit_settings_weight: Array1<f64> = self.results.get("*").get("fit_settings").get("weight").unwrap_array1();
-    //     let fit_settings_weight: Array1<f64> = fit_settings_weight.select(Axis(0), &include_indices);
-    //     // Expected value
-    //     let fit_settings_expected_value: Array1<f64> = self.results.get("*").get("fit_settings").get("expected_value").unwrap_array1();
-    //     let fit_settings_expected_value: Array1<f64> = fit_settings_expected_value.select(Axis(0), &include_indices);
+        // Sensor names
+        let sensor_names_all: Vec<String> = self.results.keys();
+        let n_sensors_all: usize = sensor_names_all.len();
+        let n_sensors: usize = include_indices.len();
 
-    //     // Greens
-    //     // With PF coils
-    //     let greens_with_pf: Array2<f64> = self.results.get("*").get("greens").get("pf").get("*").unwrap_array2(); // shape = [n_pf, n_sensors]
-    //     let greens_with_pf: Array2<f64> = greens_with_pf.select(Axis(1), &include_indices); // downselect to only the sensors needed; shape = [n_pf, n_sensors]
-    //                                                                                         // With plasma
-    //     let greens_with_grid: Array2<f64> = self.results.get("*").get("greens").get("plasma").unwrap_array2(); // shape = [n_z * n_r, n_sensors]
-    //     let greens_with_grid: Array2<f64> = greens_with_grid.select(Axis(1), &include_indices); // downselect to only the sensors needed; shape = [n_pf, n_sensors]
-    //                                                                                             // With d_sensor_dz (for vertical stability)
-    //     let greens_d_sensor_dz: Array2<f64> = self.results.get("*").get("greens").get("d_plasma_d_z").unwrap_array2(); // shape = [n_z * n_r, n_sensors]
-    //     let greens_d_sensor_dz: Array2<f64> = greens_d_sensor_dz.select(Axis(1), &include_indices); // downselect to only the sensors needed; shape = [n_z * n_r, n_sensors]
+        // Time dependent: interpolate all sensors to `times_to_reconstruct`.
+        // Note, this is done *before* the early return below, because the equilibrium
+        // post-processor always reads `["b"]["measured"]["value"]` whenever any dialoop sensor
+        // exists.
+        //
+        // Only sensors that are actually included are interpolated. For excluded sensors we store
+        // `NaN` (the post-processor ignores them), so an un-included dialoop does not force its
+        // experimental time-range onto `times_to_reconstruct` (which would otherwise panic with an
+        // out-of-bounds interpolation error).
+        let mut measured: Array2<f64> = Array2::from_elem((n_sensors_all, n_time), f64::NAN);
+        for i_sensor in 0..n_sensors_all {
+            let sensor_name: &str = &sensor_names_all[i_sensor];
 
-    //     // With passives
-    //     let passive_names: Vec<String> = self.results.get(&sensor_names[0]).get("greens").get("passives").keys();
-    //     let n_passives: usize = passive_names.len();
+            let measured_this_sensor: Array1<f64> = if include[i_sensor] {
+                let experimental_time: Array1<f64> = self.results.get(sensor_name).get("b").get("experimental").get("time").unwrap_array1();
+                let experimental_values: Array1<f64> = self.results.get(sensor_name).get("b").get("experimental").get("value").unwrap_array1();
 
-    //     // Count the number of degrees of freedom
-    //     let mut n_dof_total: usize = 0;
-    //     for passive_name in &passive_names {
-    //         let dof_names: Vec<String> = self.results.get(&sensor_names[0]).get("greens").get("passives").get(passive_name).keys();
-    //         n_dof_total += dof_names.len();
-    //     }
+                let interpolator: interpolation::Dim1Linear = interpolation::Dim1Linear::new(experimental_time.clone(), experimental_values.clone())
+                    .expect("Dialoop.split_into_static_and_dynamic: Can't make interpolator");
 
-    //     let mut greens_with_passives: Array2<f64> = Array2::zeros((n_dof_total, n_sensors));
+                interpolator
+                    .interpolate_array1(times_to_reconstruct)
+                    .expect("Dialoop.split_into_static_and_dynamic: Can't do interpolation")
+            } else {
+                // Excluded sensor: do not require the experimental data to cover the reconstruct times
+                Array1::from_elem(n_time, f64::NAN)
+            };
 
-    //     // let mut dof_names_total: Vec<String> = Vec::with_capacity(n_dof_total);
-    //     for i_sensor in 0..n_sensors {
-    //         let mut i_dof_total: usize = 0;
-    //         for i_passive in 0..n_passives {
-    //             let passive_name: &str = &passive_names[i_passive];
-    //             let dof_names: Vec<String> = self.results.get(&sensor_names[0]).get("greens").get("passives").get(passive_name).keys(); // something like ["eig01", "eig02", ...]
-    //             for dof_name in dof_names {
-    //                 greens_with_passives[(i_dof_total, i_sensor)] = self
-    //                     .results
-    //                     .get(&sensor_names[i_sensor])
-    //                     .get("greens")
-    //                     .get("passives")
-    //                     .get(&passive_name)
-    //                     .get(&dof_name)
-    //                     .unwrap_f64();
+            measured.slice_mut(s![i_sensor, ..]).assign(&measured_this_sensor);
 
-    //                 // Store the name
-    //                 // dof_names_total[i_dof_total] = dof_name;
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("b")
+                .get_or_insert("measured")
+                .insert("value", measured_this_sensor);
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("b")
+                .get_or_insert("measured")
+                .insert("time", times_to_reconstruct.clone());
+        }
 
-    //                 // Keep count
-    //                 i_dof_total += 1;
-    //             }
-    //         }
-    //     }
+        // If there are no sensors selected, return empty data
+        if n_sensors == 0 {
+            let (static_data_empty, dynamic_data_empty): (SensorsStatic, SensorsDynamic) = create_empty_sensor_data();
+            let static_data_empty_vs_time: Vec<SensorsStatic> = vec![static_data_empty; n_time];
+            let dynamic_data_empty_vs_time: Vec<SensorsDynamic> = vec![dynamic_data_empty; n_time];
+            return (static_data_empty_vs_time, dynamic_data_empty_vs_time);
+        }
 
-    //     // Create the `DialoopStatic` data
-    //     let results_static: SensorsStatic = SensorsStatic {
-    //         greens_with_grid,
-    //         greens_with_pf,
-    //         greens_with_passives,
-    //         greens_d_sensor_dz,
-    //         fit_settings_weight,
-    //         fit_settings_expected_value,
-    //     };
+        // Fit settings
+        let fit_settings_weight: Array1<f64> = self.results.get("*").get("fit_settings").get("weight").unwrap_array1();
+        let fit_settings_weight: Array1<f64> = fit_settings_weight.select(Axis(0), &include_indices);
+        let fit_settings_expected_value: Array1<f64> = self.results.get("*").get("fit_settings").get("expected_value").unwrap_array1();
+        let fit_settings_expected_value: Array1<f64> = fit_settings_expected_value.select(Axis(0), &include_indices);
 
-    //     // Time dependent
-    //     // Interpolate all sensors to `times_to_reconstruct`
-    //     let n_time: usize = times_to_reconstruct.len();
-    //     let mut measured: Array2<f64> = Array2::zeros((n_sensors_all, n_time));
-    //     for i_sensor in 0..n_sensors_all {
-    //         // Coils
-    //         let sensor_name: &str = &sensor_names_all[i_sensor];
-    //         let time_experimental: Array1<f64> = self.results.get(sensor_name).get("b").get("time_experimental").unwrap_array1();
-    //         let measured_experimental: Array1<f64> = self.results.get(sensor_name).get("b").get("measured_experimental").unwrap_array1();
+        // No Green's functions for the diamagnetic loop (see method docstring).
+        let results_static: SensorsStatic = SensorsStatic {
+            greens_with_grid: Array2::zeros((0, n_sensors)),
+            greens_with_pf: Array2::zeros((0, n_sensors)),
+            greens_with_passives: Array2::zeros((0, n_sensors)),
+            greens_d_sensor_dz: Array2::zeros((0, n_sensors)),
+            fit_settings_weight,
+            fit_settings_expected_value,
+            geometry_r: Array1::from_elem(n_sensors, f64::NAN), // dialoop is integrated; no single (r, z) position
+            geometry_z: Array1::from_elem(n_sensors, f64::NAN), // dialoop is integrated; no single (r, z) position
+        };
 
-    //         // Create the interpolator
-    //        let interpolator = interpolation::Dim1Linear::new(&time_experimental, &measured_experimental)
-    //            .expect("Coils.split_into_static_and_dynamic: Can't make interpolator");
+        // MDSplus is "Sensor-Major", but we want the data to be "Time-Major"
+        let mut results_dynamic: Vec<SensorsDynamic> = Vec::with_capacity(n_time);
+        for i_time in 0..n_time {
+            let measured_this_time_slice_and_sensors: Array1<f64> = measured.slice(s![.., i_time]).select(Axis(0), &include_indices).to_owned();
+            let results_dynamic_this_time_slice: SensorsDynamic = SensorsDynamic {
+                measured: measured_this_time_slice_and_sensors,
+            };
+            results_dynamic.push(results_dynamic_this_time_slice);
+        }
 
-    //         // Do the interpolation
-    //        let measured_this_coil: Array1<f64> = interpolator.interpolate_array1(&times_to_reconstruct)
-    //             .expect("Coils.split_into_static_and_dynamic: Can't do interpolation");
+        let results_static_time_dependent: Vec<SensorsStatic> = vec![results_static.clone(); n_time];
 
-    //         // Store for later
-    //         measured.slice_mut(s![i_sensor, ..]).assign(&measured_this_coil);
+        (results_static_time_dependent, results_dynamic)
+    }
 
-    //         // Store in self
-    //         self.results
-    //             .get_or_insert(sensor_name)
-    //             .get_or_insert("b")
-    //             .insert("measured", measured_this_coil);
-    //     }
+    /// Calculate the diamagnetic flux for each sensor and time-slice from a reconstructed plasma.
+    ///
+    /// Uses the exact toroidal flux function `f = sqrt(f_vac^2 + 2*(psi_b - psi_a)*G)`, consistent
+    /// with `epp_bt_2d` in `plasma.rs`, and integrates `(f - f_vac) / R` over the plasma mask
+    /// (Moret Eq. 41).
+    pub fn calculate_sensor_values_rs(&mut self, plasma: &Plasma) {
+        let psi_n_2d: Array3<f64> = plasma.results.get("two_d").get("psi_n").unwrap_array3(); // shape = [n_time, n_z, n_r]
+        let mask_2d: Array3<f64> = plasma.results.get("two_d").get("mask").unwrap_array3(); // shape = [n_time, n_z, n_r]
+        let flat_r: Array1<f64> = plasma.results.get("grid").get("flat").get("r").unwrap_array1(); // shape = [n_z * n_r]
+        let d_area: f64 = plasma.results.get("grid").get("d_area").unwrap_f64();
+        let time: Array1<f64> = plasma.results.get("time").unwrap_array1();
+        let psi_a_vs_time: Array1<f64> = plasma.results.get("global").get("psi_a").unwrap_array1();
+        let psi_b_vs_time: Array1<f64> = plasma.results.get("global").get("psi_b").unwrap_array1();
+        let i_rod_vs_time: Array1<f64> = plasma.results.get("global").get("i_rod").unwrap_array1();
+        let ff_coeffs: Array2<f64> = plasma.results.get("source_functions").get("ff_prime").get("coefficients").unwrap_array2(); // shape = [n_time, n_dof]
 
-    //     // MDSplus is "Sensor-Major", but we want to rearrange the data to be "Time-Major"
-    //     let mut results_dynamic: Vec<SensorsDynamic> = Vec::with_capacity(n_time);
-    //     for i_time in 0..n_time {
-    //         // Select time-slide and the sensors we use in reconstruction
-    //         let measured_this_time_slice_and_sensors: Array1<f64> = measured.slice(s![.., i_time]).select(Axis(0), &include_indices).to_owned();
-    //         // Create new `SensorsDynamic` instance and store
-    //         let results_dynamic_this_time_slice: SensorsDynamic = SensorsDynamic {
-    //             measured: measured_this_time_slice_and_sensors,
-    //         };
-    //         results_dynamic.push(results_dynamic_this_time_slice);
-    //     }
+        let n_time: usize = time.len();
 
-    //     // Return the static and dynamic results
-    //     return (results_static, results_dynamic);
-    // }
+        for sensor_name in self.results.keys() {
+            let mut values: Array1<f64> = Array1::zeros(n_time);
 
-    /// Calculate the sensor values
-    pub fn calculate_sensor_values_rust(&mut self, plasma: &Plasma) {
-        for sensor_name in self.results.keys() {}
+            for i_time in 0..n_time {
+                let psi_n_flat: Array1<f64> = Array1::from_iter(psi_n_2d.slice(s![i_time, .., ..]).iter().copied());
+                let mask_flat: Array1<f64> = Array1::from_iter(mask_2d.slice(s![i_time, .., ..]).iter().copied());
+                let ff_dof: Array1<f64> = ff_coeffs.slice(s![i_time, ..]).to_owned();
+
+                // Vacuum toroidal flux function: f_vac = R0 * B_phi0 = MU_0 * i_rod / (2 * PI)
+                let f_vac: f64 = MU_0 * i_rod_vs_time[i_time] / (2.0 * PI);
+
+                // G(psi_n) = sum_i ff'_dof[i] * ff'_integral_i(psi_n)
+                let g_integral: Array1<f64> = plasma.ff_prime_source_function.source_function_integral(&psi_n_flat, &ff_dof);
+
+                // f = sqrt( f_vac^2 + 2*(psi_b - psi_a)*G ), then (f - f_vac)
+                let d_psi: f64 = psi_b_vs_time[i_time] - psi_a_vs_time[i_time];
+                let f_squared: Array1<f64> = 2.0 * d_psi * &g_integral + f_vac * f_vac;
+                let f_minus_f_vac: Array1<f64> = f_squared.mapv(f64::sqrt) - f_vac;
+
+                // Phi_t = integral( mask * (f - f_vac) / R ) dA
+                let integrand: Array1<f64> = &mask_flat * &f_minus_f_vac / &flat_r;
+                values[i_time] = integrand.sum() * d_area;
+            }
+
+            self.results.get_or_insert(&sensor_name).get_or_insert("b").get_or_insert("calculated").insert("value", values.clone());
+            self.results.get_or_insert(&sensor_name).get_or_insert("b").get_or_insert("calculated").insert("time", time.clone());
+        }
     }
 }

--- a/rust/gsfit_rs/src/sensors/dialoop.rs
+++ b/rust/gsfit_rs/src/sensors/dialoop.rs
@@ -264,10 +264,14 @@ impl Dialoop {
                 // G(psi_n) = sum_i ff'_dof[i] * ff'_integral_i(psi_n)
                 let g_integral: Array1<f64> = plasma.ff_prime_source_function.source_function_integral(&psi_n_flat, &ff_dof);
 
-                // f = sqrt( f_vac^2 + 2*(psi_b - psi_a)*G ), then (f - f_vac)
+                // f = sign(f_vac) * sqrt( f_vac^2 + 2*(psi_b - psi_a)*G ), then (f - f_vac)
+                // The sign of f_vac must be preserved so that a negative TF rod current
+                // (f_vac < 0) yields a negative f, matching the vacuum boundary condition
+                // f(psi_n = 1) = f_vac; otherwise the diamagnetic flux gets the wrong sign.
+                let f_sign: f64 = if f_vac >= 0.0 { 1.0 } else { -1.0 };
                 let d_psi: f64 = psi_b_vs_time[i_time] - psi_a_vs_time[i_time];
                 let f_squared: Array1<f64> = 2.0 * d_psi * &g_integral + f_vac * f_vac;
-                let f_minus_f_vac: Array1<f64> = f_squared.mapv(f64::sqrt) - f_vac;
+                let f_minus_f_vac: Array1<f64> = f_sign * f_squared.mapv(f64::sqrt) - f_vac;
 
                 // Phi_t = integral( mask * (f - f_vac) / R ) dA
                 let integrand: Array1<f64> = &mask_flat * &f_minus_f_vac / &flat_r;

--- a/rust/gsfit_rs/src/source_functions/efit_polynomial.rs
+++ b/rust/gsfit_rs/src/source_functions/efit_polynomial.rs
@@ -64,9 +64,35 @@ impl SourceFunctionTraits for EfitPolynomial {
         unimplemented!("Source function is not implemented yet");
     }
 
+    /// Integral of a single degree of freedom
+    ///
+    /// We take the integral from 1 to `psi_n`, this ensures that the integral is zero at `psi_n = 1`.
+    ///
+    /// The source function value for degree of freedom `i_dof` is:
+    ///   src(ψₙ) = (1 − ψₙ) · ψₙ^i_dof
+    ///
+    /// Its antiderivative is:
+    ///   antideriv(ψₙ) = ψₙ^(i_dof+1) / (i_dof+1) − ψₙ^(i_dof+2) / (i_dof+2)
+    ///
+    /// The definite integral from 1 to ψₙ is:
+    ///   ∫_1^ψₙ src(y) dy = antideriv(ψₙ) − antideriv(1)
+    ///                    = ψₙ^(i_dof+1)/(i_dof+1) − ψₙ^(i_dof+2)/(i_dof+2)
+    ///                      − 1/(i_dof+1) + 1/(i_dof+2)
+    ///
+    /// # Arguments
+    /// * `psi_n` - The points at which we want to evaluate the integral
+    /// * `i_dof` - The index of the degree of freedom to evaluate
+    ///
+    /// # Returns
+    /// An array of the same length as `psi_n` containing the integral of the source function
+    /// for the specified degree of freedom, which is zero at `psi_n = 1`.
     fn source_function_integral_single_dof(&self, psi_n: &Array1<f64>, i_dof: usize) -> Array1<f64> {
-        // TODO: Indefinite integral, so constant of integration might need to be added
-        let integral: Array1<f64> = (1.0 - psi_n / 2.0) * psi_n.mapv(|x| x.powi(i_dof as i32 + 1)) / (i_dof as f64 + 1.0);
+        let i_dof_f64: f64 = i_dof as f64;
+        // antideriv(1) = 1/(i_dof+1) - 1/(i_dof+2), subtracted to shift the integral so it is zero at psi_n = 1
+        let integration_constant: f64 = -1.0 / (i_dof_f64 + 1.0) + 1.0 / (i_dof_f64 + 2.0);
+        let integral: Array1<f64> = psi_n.mapv(|x| x.powi(i_dof as i32 + 1)) / (i_dof_f64 + 1.0)
+            - psi_n.mapv(|x| x.powi(i_dof as i32 + 2)) / (i_dof_f64 + 2.0)
+            + integration_constant;
 
         integral
     }
@@ -92,17 +118,12 @@ impl SourceFunctionTraits for EfitPolynomial {
         let n_dof: usize = self.n_dof;
         let n_psi_n: usize = psi_n.len();
 
-        let mut constant_of_integration: f64 = 0.0;
-        let psi_edge: Array1<f64> = Array1::from_vec(vec![1.0]);
-        for i_dof in 0..n_dof {
-            constant_of_integration -= polynomial_dof[i_dof] * self.source_function_integral_single_dof(&psi_edge, i_dof)[0];
-        }
-
+        // No constant of integration needed: `source_function_integral_single_dof` already
+        // integrates from 1 to psi_n, so the sum is guaranteed to be zero at psi_n = 1.
         let mut integral: Array1<f64> = Array1::zeros(n_psi_n);
         for i_dof in 0..n_dof {
             integral = integral + polynomial_dof[i_dof] * self.source_function_integral_single_dof(psi_n, i_dof);
         }
-        integral += constant_of_integration;
 
         integral
     }


### PR DESCRIPTION
## Summary
Adds the diamagnetic loop (`DIALOOP`) as an optional constraint in the
inverse Grad-Shafranov reconstruction.

Unlike the magnetic sensors, the diamagnetic loop responds to the toroidal
flux function `f` (the poloidal-current function), which depends only on
the `ff'` source function. It therefore uses **no Green's functions** and
adds no p', passive, coil or vertical-stabilisation terms.

## How it works
The diamagnetic flux is computed as (Moret Eq. 41):

    Phi_t = integral( (f - f_vac) / R ) dA      (over the plasma mask)

with `f = sqrt(f_vac^2 + 2*(psi_b - psi_a)*G)`, `G = sum_i ff'_dof[i] *
ff'_integral_i(psi_n)`, and `f_vac = MU_0 * i_rod / (2*PI)`. For the fit
this is linearised for small diamagnetism, giving a constraint row that is
linear in the `ff'` degrees of freedom.

## Changes
**Rust**
- `gs_solution.rs`: new DIALOOP constraint row.
- `grad_shafranov_solver.rs`: wire dialoop static/dynamic data; pass
  per-time-slice TF rod current (`i_rod`) for `f_vac`.
- `dialoop.rs`: implement `split_into_static_and_dynamic` and
  `calculate_sensor_values`; only interpolate included sensors (excluded
  ones store NaN).
- `epp_chi_sq_mag.rs`: include DIALOOP in `chi_sq_mag`.

**Python**
- `setup_dialoop.py`: read `PHI_DIA` from the DIALOOP tree and loop-path
  geometry from MAG; populate fit settings.
- `gsfit.py`: initialise dialoop and pass it to the solver.
- `map_results_to_database.py`: write `CONSTRAINTS.DIAMAG_FLUX`
  (measured/reconstructed/weight/include).
- settings: dialoop database-reader workflow entry; default DIALOOP
  weights (`include=false`).

**Examples**
- `example_12__st40__dialoop_example.py`.

## Behaviour / compatibility
- `include = false` by default, so existing runs are unaffected.
- Setting `include = false` cleanly drops the DIALOOP from the fit and doesn't require its experimental data to span the reconstruct times.

## Testing
- `cargo check -p gsfit_rs` passes.
- Ran `example_12` (and `example_01`) on pulse 14681 with the DIALOOP
  included and excluded.