### PR TITLE
Replace compact current hill with quadratic initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ To improve reliability and traceability, the number of arguments needed to initi
 The `settings_path="default"` argument tells GSFit to use the settings (JSON files) from this directory [`python/gsfit/settings/default/`](python/gsfit/settings/default/).
 By storing all the settings needed to run GSFit in JSON files allows changes to be tracked through Git.
 
+### Initial plasma-current guess
+
+The initial toroidal current density is a smooth quadratic distribution centred at `r_cur`, `z_cur`:
+
+```text
+j_phi(R, Z) = C * max(1 - ((R - r_cur) / minor_radius)^2
+                          - ((Z - z_cur) / (minor_radius * kappa))^2, 0)
+```
+
+`C` is calculated on the discrete plasma grid so that the integrated current equals the configured initial `ip`. The edge of this current-density support is an initial numerical guess, not an LCFS or an inverse-problem constraint. The configured ellipse must lie inside the plasma grid and vessel and must not contain a limiter point.
+
+Custom settings directories must add `minor_radius` in metres and dimensionless `kappa` to the `initial_guess` section of `GSFIT_code_settings.json`. Direct callers of `gsfit_rs.Plasma(...)` must likewise pass `initial_minor_radius` and `initial_kappa`; these are required constructor arguments.
+
 ## 2.2 Adding a new experimental device or coupling to a new forward Grad-Shafranov code
 The information needed to run GSFit comes from two sources:
 

--- a/python/gsfit/database_readers/freegs/setup_plasma.py
+++ b/python/gsfit/database_readers/freegs/setup_plasma.py
@@ -35,6 +35,8 @@ def setup_plasma(
     initial_ip = settings["GSFIT_code_settings.json"]["initial_guess"]["ip"]
     initial_cur_r = settings["GSFIT_code_settings.json"]["initial_guess"]["r_cur"]
     initial_cur_z = settings["GSFIT_code_settings.json"]["initial_guess"]["z_cur"]
+    initial_minor_radius = settings["GSFIT_code_settings.json"]["initial_guess"]["minor_radius"]
+    initial_kappa = settings["GSFIT_code_settings.json"]["initial_guess"]["kappa"]
 
     # Set the source functions types
     p_prime_source_function: gsfit_rs.EfitPolynomial | gsfit_rs.TensionedCubicBSpline
@@ -120,6 +122,8 @@ def setup_plasma(
         initial_ip,
         initial_cur_r,
         initial_cur_z,
+        initial_minor_radius,
+        initial_kappa,
     )
 
     return plasma

--- a/python/gsfit/database_readers/freegsnke/setup_plasma.py
+++ b/python/gsfit/database_readers/freegsnke/setup_plasma.py
@@ -33,6 +33,8 @@ def setup_plasma(
     initial_ip = settings["GSFIT_code_settings.json"]["initial_guess"]["ip"]
     initial_cur_r = settings["GSFIT_code_settings.json"]["initial_guess"]["r_cur"]
     initial_cur_z = settings["GSFIT_code_settings.json"]["initial_guess"]["z_cur"]
+    initial_minor_radius = settings["GSFIT_code_settings.json"]["initial_guess"]["minor_radius"]
+    initial_kappa = settings["GSFIT_code_settings.json"]["initial_guess"]["kappa"]
 
     # Set the source functions types
     p_prime_source_function: gsfit_rs.EfitPolynomial | gsfit_rs.TensionedCubicBSpline
@@ -121,6 +123,8 @@ def setup_plasma(
         initial_ip,
         initial_cur_r,
         initial_cur_z,
+        initial_minor_radius,
+        initial_kappa,
     )
 
     return plasma

--- a/python/gsfit/database_readers/interface.py
+++ b/python/gsfit/database_readers/interface.py
@@ -403,6 +403,11 @@ class DatabaseReaderProtocol(Protocol):
             vessel_z=...,                                       # read from `GSFIT_code_settings.json` file
             p_prime_source_function=p_prime_source_function,    # built above
             ff_prime_source_function=ff_prime_source_function,  # built above
+            initial_ip=...,                                     # read from `GSFIT_code_settings.json` file
+            initial_cur_r=...,                                  # read from `GSFIT_code_settings.json` file
+            initial_cur_z=...,                                  # read from `GSFIT_code_settings.json` file
+            initial_minor_radius=...,                            # read from `GSFIT_code_settings.json` file
+            initial_kappa=...,                                  # read from `GSFIT_code_settings.json` file
         )
 
         return plasma

--- a/python/gsfit/database_readers/mock_st40_mdsplus/setup_plasma.py
+++ b/python/gsfit/database_readers/mock_st40_mdsplus/setup_plasma.py
@@ -33,6 +33,8 @@ def setup_plasma(
     initial_ip = settings["GSFIT_code_settings.json"]["initial_guess"]["ip"]
     initial_cur_r = settings["GSFIT_code_settings.json"]["initial_guess"]["r_cur"]
     initial_cur_z = settings["GSFIT_code_settings.json"]["initial_guess"]["z_cur"]
+    initial_minor_radius = settings["GSFIT_code_settings.json"]["initial_guess"]["minor_radius"]
+    initial_kappa = settings["GSFIT_code_settings.json"]["initial_guess"]["kappa"]
 
     # Set the source functions types
     p_prime_source_function = build_source_function(settings["source_function_p_prime.json"])
@@ -84,6 +86,8 @@ def setup_plasma(
         initial_ip,
         initial_cur_r,
         initial_cur_z,
+        initial_minor_radius,
+        initial_kappa,
     )
 
     return plasma

--- a/python/gsfit/database_readers/st40_astra_mdsplus/setup_plasma.py
+++ b/python/gsfit/database_readers/st40_astra_mdsplus/setup_plasma.py
@@ -31,6 +31,8 @@ def setup_plasma(
     initial_ip = settings["GSFIT_code_settings.json"]["initial_guess"]["ip"]
     initial_cur_r = settings["GSFIT_code_settings.json"]["initial_guess"]["r_cur"]
     initial_cur_z = settings["GSFIT_code_settings.json"]["initial_guess"]["z_cur"]
+    initial_minor_radius = settings["GSFIT_code_settings.json"]["initial_guess"]["minor_radius"]
+    initial_kappa = settings["GSFIT_code_settings.json"]["initial_guess"]["kappa"]
 
     # Set the source functions types
     p_prime_source_function: gsfit_rs.EfitPolynomial | gsfit_rs.TensionedCubicBSpline
@@ -125,6 +127,8 @@ def setup_plasma(
         initial_ip,
         initial_cur_r,
         initial_cur_z,
+        initial_minor_radius,
+        initial_kappa,
     )
 
     return plasma

--- a/python/gsfit/database_readers/st40_mdsplus/setup_plasma.py
+++ b/python/gsfit/database_readers/st40_mdsplus/setup_plasma.py
@@ -31,6 +31,8 @@ def setup_plasma(
     initial_ip = settings["GSFIT_code_settings.json"]["initial_guess"]["ip"]
     initial_cur_r = settings["GSFIT_code_settings.json"]["initial_guess"]["r_cur"]
     initial_cur_z = settings["GSFIT_code_settings.json"]["initial_guess"]["z_cur"]
+    initial_minor_radius = settings["GSFIT_code_settings.json"]["initial_guess"]["minor_radius"]
+    initial_kappa = settings["GSFIT_code_settings.json"]["initial_guess"]["kappa"]
 
     # Set the source functions types
     p_prime_source_function: gsfit_rs.EfitPolynomial | gsfit_rs.TensionedCubicBSpline
@@ -125,6 +127,8 @@ def setup_plasma(
         initial_ip,
         initial_cur_r,
         initial_cur_z,
+        initial_minor_radius,
+        initial_kappa,
     )
 
     return plasma

--- a/python/gsfit/database_readers/st40_mdsplus_with_digital_filter/setup_plasma.py
+++ b/python/gsfit/database_readers/st40_mdsplus_with_digital_filter/setup_plasma.py
@@ -31,6 +31,8 @@ def setup_plasma(
     initial_ip = settings["GSFIT_code_settings.json"]["initial_guess"]["ip"]
     initial_cur_r = settings["GSFIT_code_settings.json"]["initial_guess"]["r_cur"]
     initial_cur_z = settings["GSFIT_code_settings.json"]["initial_guess"]["z_cur"]
+    initial_minor_radius = settings["GSFIT_code_settings.json"]["initial_guess"]["minor_radius"]
+    initial_kappa = settings["GSFIT_code_settings.json"]["initial_guess"]["kappa"]
 
     # Set the source functions types
     p_prime_source_function: gsfit_rs.EfitPolynomial | gsfit_rs.TensionedCubicBSpline
@@ -125,6 +127,8 @@ def setup_plasma(
         initial_ip,
         initial_cur_r,
         initial_cur_z,
+        initial_minor_radius,
+        initial_kappa,
     )
 
     return plasma

--- a/python/gsfit/database_readers/st40_spider_mdsplus/setup_plasma.py
+++ b/python/gsfit/database_readers/st40_spider_mdsplus/setup_plasma.py
@@ -31,6 +31,8 @@ def setup_plasma(
     initial_ip = settings["GSFIT_code_settings.json"]["initial_guess"]["ip"]
     initial_cur_r = settings["GSFIT_code_settings.json"]["initial_guess"]["r_cur"]
     initial_cur_z = settings["GSFIT_code_settings.json"]["initial_guess"]["z_cur"]
+    initial_minor_radius = settings["GSFIT_code_settings.json"]["initial_guess"]["minor_radius"]
+    initial_kappa = settings["GSFIT_code_settings.json"]["initial_guess"]["kappa"]
 
     # Set the source functions types
     p_prime_source_function: gsfit_rs.EfitPolynomial
@@ -103,6 +105,8 @@ def setup_plasma(
         initial_ip,
         initial_cur_r,
         initial_cur_z,
+        initial_minor_radius,
+        initial_kappa,
     )
 
     return plasma

--- a/python/gsfit/settings/default/GSFIT_code_settings.json
+++ b/python/gsfit/settings/default/GSFIT_code_settings.json
@@ -147,7 +147,7 @@
         "ip": 425.0e3,
         "r_cur": 0.45,
         "z_cur": 0.0,
-        "minor_radius": 0.275,
-        "kappa": 1.7
+        "minor_radius": 0.2,
+        "kappa": 1.2
     }
 }

--- a/python/gsfit/settings/default/GSFIT_code_settings.json
+++ b/python/gsfit/settings/default/GSFIT_code_settings.json
@@ -146,6 +146,8 @@
     "initial_guess": {
         "ip": 425.0e3,
         "r_cur": 0.45,
-        "z_cur": 0.0
+        "z_cur": 0.0,
+        "minor_radius": 0.275,
+        "kappa": 1.7
     }
 }

--- a/python/gsfit/settings/mastu_with_synthetic_data_from_freegsnke/GSFIT_code_settings.json
+++ b/python/gsfit/settings/mastu_with_synthetic_data_from_freegsnke/GSFIT_code_settings.json
@@ -100,6 +100,8 @@
     "initial_guess": {
         "ip": 500.0e3,
         "r_cur": 0.8,
-        "z_cur": 0.0
+        "z_cur": 0.0,
+        "minor_radius": 0.5,
+        "kappa": 2.0
     }
 }

--- a/python/gsfit/settings/st40_P2p3_calibrations/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_P2p3_calibrations/GSFIT_code_settings.json
@@ -147,7 +147,7 @@
         "ip": 425.0e3,
         "r_cur": 0.45,
         "z_cur": 0.0,
-        "minor_radius": 0.275,
-        "kappa": 1.7
+        "minor_radius": 0.2,
+        "kappa": 1.2
     }
 }

--- a/python/gsfit/settings/st40_P2p3_calibrations/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_P2p3_calibrations/GSFIT_code_settings.json
@@ -146,6 +146,8 @@
     "initial_guess": {
         "ip": 425.0e3,
         "r_cur": 0.45,
-        "z_cur": 0.0
+        "z_cur": 0.0,
+        "minor_radius": 0.275,
+        "kappa": 1.7
     }
 }

--- a/python/gsfit/settings/st40_all_magnetic_sensors_working/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_all_magnetic_sensors_working/GSFIT_code_settings.json
@@ -96,6 +96,8 @@
     "initial_guess": {
         "ip": 425.0e3,
         "r_cur": 0.45,
-        "z_cur": 0.0
+        "z_cur": 0.0,
+        "minor_radius": 0.275,
+        "kappa": 1.7
     }
 }

--- a/python/gsfit/settings/st40_all_magnetic_sensors_working/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_all_magnetic_sensors_working/GSFIT_code_settings.json
@@ -97,7 +97,7 @@
         "ip": 425.0e3,
         "r_cur": 0.45,
         "z_cur": 0.0,
-        "minor_radius": 0.275,
-        "kappa": 1.7
+        "minor_radius": 0.2,
+        "kappa": 1.2
     }
 }

--- a/python/gsfit/settings/st40_setup_for_rtgsfit/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_setup_for_rtgsfit/GSFIT_code_settings.json
@@ -92,6 +92,8 @@
     "initial_guess": {
         "ip": 425.0e3,
         "r_cur": 0.45,
-        "z_cur": 0.0
+        "z_cur": 0.0,
+        "minor_radius": 0.275,
+        "kappa": 1.7
     }
 }

--- a/python/gsfit/settings/st40_setup_for_rtgsfit/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_setup_for_rtgsfit/GSFIT_code_settings.json
@@ -93,7 +93,7 @@
         "ip": 425.0e3,
         "r_cur": 0.45,
         "z_cur": 0.0,
-        "minor_radius": 0.275,
-        "kappa": 1.7
+        "minor_radius": 0.2,
+        "kappa": 1.2
     }
 }

--- a/python/gsfit/settings/st40_with_synthetic_data_from_astra/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_with_synthetic_data_from_astra/GSFIT_code_settings.json
@@ -114,7 +114,7 @@
         "ip": 425.0e3,
         "r_cur": 0.45,
         "z_cur": 0.0,
-        "minor_radius": 0.275,
-        "kappa": 1.7
+        "minor_radius": 0.2,
+        "kappa": 1.2
     }
 }

--- a/python/gsfit/settings/st40_with_synthetic_data_from_astra/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_with_synthetic_data_from_astra/GSFIT_code_settings.json
@@ -113,6 +113,8 @@
     "initial_guess": {
         "ip": 425.0e3,
         "r_cur": 0.45,
-        "z_cur": 0.0
+        "z_cur": 0.0,
+        "minor_radius": 0.275,
+        "kappa": 1.7
     }
 }

--- a/python/gsfit/settings/st40_with_synthetic_data_from_spider/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_with_synthetic_data_from_spider/GSFIT_code_settings.json
@@ -79,7 +79,9 @@
   "initial_guess": {
     "ip": 425000.0,
     "r_cur": 0.45,
-    "z_cur": 0.0
+    "z_cur": 0.0,
+    "minor_radius": 0.275,
+    "kappa": 1.7
   },
   "n_psi_n": 100,
   "numerics": {

--- a/python/gsfit/settings/st40_with_synthetic_data_from_spider/GSFIT_code_settings.json
+++ b/python/gsfit/settings/st40_with_synthetic_data_from_spider/GSFIT_code_settings.json
@@ -80,8 +80,8 @@
     "ip": 425000.0,
     "r_cur": 0.45,
     "z_cur": 0.0,
-    "minor_radius": 0.275,
-    "kappa": 1.7
+    "minor_radius": 0.2,
+    "kappa": 1.2
   },
   "n_psi_n": 100,
   "numerics": {

--- a/python/gsfit_rs/gsfit_rs.pyi
+++ b/python/gsfit_rs/gsfit_rs.pyi
@@ -431,6 +431,8 @@ class Plasma(DataTreeAccessor):
         initial_ip: float,
         initial_cur_r: float,
         initial_cur_z: float,
+        initial_minor_radius: float,
+        initial_kappa: float,
     ) -> Plasma:
         """
         :param n_r: Number of radial poitns [dimensionless]
@@ -447,8 +449,10 @@ class Plasma(DataTreeAccessor):
         :param p_prime_source_function: `p_prime` source function, needs to be constructed from `gsfit_rs.<source_function_name>`
         :param ff_prime_source_function: `p_prime` source function, needs to be constructed from `gsfit_rs.<source_function_name>`
         :param initial_ip: Initial plasma current [ampere]
-        :param initial_r: Initial major radius of the magnetic axis [metre]
-        :param initial_z: Initial vertical position of the magnetic axis [metre]
+        :param initial_cur_r: Radial centre of the initial current distribution [metre]
+        :param initial_cur_z: Vertical centre of the initial current distribution [metre]
+        :param initial_minor_radius: Radial semi-axis of the initial current distribution [metre]
+        :param initial_kappa: Elongation of the initial current distribution [dimensionless]
         """
         ...
     def greens_with_coils(

--- a/python/gsfit_rs/self_test.py
+++ b/python/gsfit_rs/self_test.py
@@ -122,6 +122,8 @@ def run() -> None:
         initial_ip=ip_guess,
         initial_cur_r=10.5,
         initial_cur_z=0.0,
+        initial_minor_radius=0.5,
+        initial_kappa=2.0,
     )
 
     passives = Passives()

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -97,7 +97,11 @@ fn quadratic_current_density_seed(
 
     // For an ellipse scaled by lambda, a grid point is in its support when
     // s_base < lambda^2. Limit lambda using the nearest point outside the
-    // vessel, so no outside grid point receives nonzero current.
+    // vessel, so no outside grid-point centre receives nonzero current. A
+    // finite source cell next to the wall can still extend partly outside the
+    // vessel polygon. The edge of this initial J_phi support is not an LCFS;
+    // the first-iteration plasma boundary is found separately from the total
+    // poloidal flux, including the PF-coil contribution.
     let mut scale_squared: f64 = 1.0;
     for &z_value in z {
         for &r_value in r {
@@ -111,6 +115,10 @@ fn quadratic_current_density_seed(
         return Err("vessel geometry leaves no finite quadratic-current support around the initial centre".to_string());
     }
 
+    // If operational experience shows that user control is needed, an optional
+    // `initial_current_scale` in (0, 1] can multiply this automatic scale. Such
+    // a factor would preserve the centre and aspect ratio, only shrink the
+    // support, and leave the total current unchanged after normalisation.
     let scale = scale_squared.sqrt();
     let a_r = a_r_base * scale;
     let b_z = b_z_base * scale;

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -14,6 +14,7 @@ use faer::linalg::matmul::matmul;
 use faer::linalg::solvers::{SolveLstsq, Svd as FaerSvd};
 use faer::mat::MatRef;
 use faer::{Accum, Par};
+use geo::{Contains, Coord, LineString, Point, Polygon};
 use ndarray::Axis;
 use ndarray::{Array1, Array2, Array3, ArrayView2, concatenate, s};
 use ndarray_stats::QuantileExt;
@@ -21,6 +22,179 @@ use std::f64::consts::PI;
 use std::sync::Arc;
 
 const MU_0: f64 = physical_constants::VACUUM_MAG_PERMEABILITY;
+
+/// Create a smooth, axis-aligned quadratic current-density seed.
+///
+/// The ellipse is centred on the supplied initial magnetic-axis guess. Its
+/// aspect ratio comes from the available radial and vertical extents of the
+/// vessel and computational grid. Both semi-axes are then reduced by the same
+/// factor until every grid point with nonzero current lies inside the vessel.
+/// The discrete current is normalised to `initial_ip` within floating-point
+/// precision.
+fn quadratic_current_density_seed(
+    r: &Array1<f64>,
+    z: &Array1<f64>,
+    vessel_r: &Array1<f64>,
+    vessel_z: &Array1<f64>,
+    d_area: f64,
+    initial_ip: f64,
+    initial_cur_r: f64,
+    initial_cur_z: f64,
+) -> Result<Array2<f64>, String> {
+    if r.len() < 2 || z.len() < 2 {
+        return Err("quadratic current initialisation requires at least two radial and vertical grid points".to_string());
+    }
+    if vessel_r.len() != vessel_z.len() || vessel_r.len() < 3 {
+        return Err("quadratic current initialisation requires matching vessel R/Z arrays with at least three points".to_string());
+    }
+    if r.iter()
+        .chain(z.iter())
+        .chain(vessel_r.iter())
+        .chain(vessel_z.iter())
+        .any(|value| !value.is_finite())
+        || !d_area.is_finite()
+        || d_area <= 0.0
+        || !initial_ip.is_finite()
+        || initial_ip == 0.0
+        || !initial_cur_r.is_finite()
+        || !initial_cur_z.is_finite()
+    {
+        return Err("quadratic current initialisation requires finite geometry, positive cell area, and finite nonzero initial current".to_string());
+    }
+
+    let vessel_coordinates: Vec<Coord<f64>> = vessel_r
+        .iter()
+        .zip(vessel_z.iter())
+        .map(|(&r_value, &z_value)| Coord { x: r_value, y: z_value })
+        .collect();
+    let vessel_polygon = Polygon::new(LineString::new(vessel_coordinates), vec![]);
+    if !vessel_polygon.contains(&Point::new(initial_cur_r, initial_cur_z)) {
+        return Err(format!(
+            "initial current centre ({initial_cur_r}, {initial_cur_z}) must lie strictly inside the vessel"
+        ));
+    }
+
+    let min_max = |values: &Array1<f64>| -> (f64, f64) {
+        values.iter().fold((f64::INFINITY, f64::NEG_INFINITY), |(minimum, maximum), &value| {
+            (minimum.min(value), maximum.max(value))
+        })
+    };
+    let (grid_r_min, grid_r_max) = min_max(r);
+    let (grid_z_min, grid_z_max) = min_max(z);
+    let (vessel_r_min, vessel_r_max) = min_max(vessel_r);
+    let (vessel_z_min, vessel_z_max) = min_max(vessel_z);
+    let a_r_base = (initial_cur_r - grid_r_min)
+        .min(grid_r_max - initial_cur_r)
+        .min(initial_cur_r - vessel_r_min)
+        .min(vessel_r_max - initial_cur_r);
+    let b_z_base = (initial_cur_z - grid_z_min)
+        .min(grid_z_max - initial_cur_z)
+        .min(initial_cur_z - vessel_z_min)
+        .min(vessel_z_max - initial_cur_z);
+    if !a_r_base.is_finite() || !b_z_base.is_finite() || a_r_base <= 0.0 || b_z_base <= 0.0 {
+        return Err("initial current centre must have positive radial and vertical clearance inside the grid and vessel".to_string());
+    }
+
+    // For an ellipse scaled by lambda, a grid point is in its support when
+    // s_base < lambda^2. Limit lambda using the nearest point outside the
+    // vessel, so no outside grid point receives nonzero current.
+    let mut scale_squared: f64 = 1.0;
+    for &z_value in z {
+        for &r_value in r {
+            if !vessel_polygon.contains(&Point::new(r_value, z_value)) {
+                let s_base = ((r_value - initial_cur_r) / a_r_base).powi(2) + ((z_value - initial_cur_z) / b_z_base).powi(2);
+                scale_squared = scale_squared.min(s_base);
+            }
+        }
+    }
+    if !scale_squared.is_finite() || scale_squared <= f64::EPSILON {
+        return Err("vessel geometry leaves no finite quadratic-current support around the initial centre".to_string());
+    }
+
+    let scale = scale_squared.sqrt();
+    let a_r = a_r_base * scale;
+    let b_z = b_z_base * scale;
+    let mut shape = Array2::zeros((z.len(), r.len()));
+    for (i_z, &z_value) in z.iter().enumerate() {
+        for (i_r, &r_value) in r.iter().enumerate() {
+            if vessel_polygon.contains(&Point::new(r_value, z_value)) {
+                let s = ((r_value - initial_cur_r) / a_r).powi(2) + ((z_value - initial_cur_z) / b_z).powi(2);
+                shape[(i_z, i_r)] = (1.0 - s).max(0.0);
+            }
+        }
+    }
+
+    let shape_integral = shape.sum() * d_area;
+    if !shape_integral.is_finite() || shape_integral <= 0.0 {
+        return Err("quadratic current initialisation has empty support on the plasma grid".to_string());
+    }
+    return Ok(shape * (initial_ip / shape_integral));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quadratic_current_density_seed;
+    use geo::{Contains, Coord, LineString, Point, Polygon};
+    use ndarray::{Array1, array};
+
+    #[test]
+    fn quadratic_current_seed_is_normalised_smooth_and_inside_vessel() {
+        let r = Array1::linspace(1.0, 3.0, 9);
+        let z = Array1::linspace(-1.0, 1.0, 9);
+        let vessel_r = array![2.0, 3.0, 2.0, 1.0, 2.0];
+        let vessel_z = array![1.0, 0.0, -1.0, 0.0, 1.0];
+        let d_area = (r[1] - r[0]) * (z[1] - z[0]);
+        let initial_ip = 120_000.0;
+
+        let j_2d = quadratic_current_density_seed(&r, &z, &vessel_r, &vessel_z, d_area, initial_ip, 2.0, 0.0).unwrap();
+
+        assert!((j_2d.sum() * d_area - initial_ip).abs() < 1.0e-10 * initial_ip);
+        assert!(j_2d[(4, 4)] > j_2d[(4, 5)]);
+        assert!(j_2d[(4, 5)] > j_2d[(4, 6)]);
+        assert!((j_2d[(4, 5)] / j_2d[(4, 4)] - 0.875).abs() < 1.0e-12);
+        assert!((j_2d[(4, 6)] / j_2d[(4, 4)] - 0.5).abs() < 1.0e-12);
+
+        let vessel_coordinates: Vec<Coord<f64>> = vessel_r
+            .iter()
+            .zip(vessel_z.iter())
+            .map(|(&r_value, &z_value)| Coord { x: r_value, y: z_value })
+            .collect();
+        let vessel_polygon = Polygon::new(LineString::new(vessel_coordinates), vec![]);
+        for (i_z, &z_value) in z.iter().enumerate() {
+            for (i_r, &r_value) in r.iter().enumerate() {
+                if j_2d[(i_z, i_r)] != 0.0 {
+                    assert!(vessel_polygon.contains(&Point::new(r_value, z_value)));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn quadratic_current_seed_preserves_negative_current_sign() {
+        let r = Array1::linspace(1.0, 3.0, 9);
+        let z = Array1::linspace(-1.0, 1.0, 9);
+        let vessel_r = array![0.9, 3.1, 3.1, 0.9, 0.9];
+        let vessel_z = array![-1.1, -1.1, 1.1, 1.1, -1.1];
+        let d_area = (r[1] - r[0]) * (z[1] - z[0]);
+
+        let j_2d = quadratic_current_density_seed(&r, &z, &vessel_r, &vessel_z, d_area, -80_000.0, 2.0, 0.0).unwrap();
+
+        assert!((j_2d.sum() * d_area + 80_000.0).abs() < 1.0e-8);
+        assert!(j_2d.iter().all(|value| *value <= 0.0));
+    }
+
+    #[test]
+    fn quadratic_current_seed_rejects_centre_outside_vessel() {
+        let r = Array1::linspace(1.0, 3.0, 9);
+        let z = Array1::linspace(-1.0, 1.0, 9);
+        let vessel_r = array![1.5, 2.5, 2.5, 1.5, 1.5];
+        let vessel_z = array![-0.5, -0.5, 0.5, 0.5, -0.5];
+
+        let error = quadratic_current_density_seed(&r, &z, &vessel_r, &vessel_z, 0.0625, 10_000.0, 1.25, 0.0).unwrap_err();
+
+        assert!(error.contains("strictly inside the vessel"));
+    }
+}
 
 /// Greens tables reorganised for `calculate_psi_and_derivatives`.
 ///
@@ -487,8 +661,13 @@ impl<'a> GsSolution<'a> {
         // TODO: IDEA- change the normalisation so that it does represent current. But this won't work for the IVC eigenvalues
         self.passive_dof_values = Array1::zeros(n_passive_dof);
 
-        // Initialise plasma with point source current
-        self.initialise_plasma_with_point_source_current(plasma.initial_ip, plasma.initial_cur_r, plasma.initial_cur_z);
+        // Initialise plasma with a smooth quadratic current-density distribution.
+        if let Err(reason) = self.initialise_plasma_with_quadratic_current_density(plasma.initial_ip, plasma.initial_cur_r, plasma.initial_cur_z) {
+            self.set_to_failed_time_slice();
+            self.error_state = Some(Error::InvalidInitialCurrent(reason));
+            println!("{:?}", self.error_state.as_ref().unwrap());
+            return;
+        }
 
         // Some variables we want to track between iterations
         let mut dof_values_previous: Array1<f64> = Array1::zeros(n_p_prime_dof + n_ff_prime_dof + n_passive_dof + 1);
@@ -1535,7 +1714,7 @@ impl<'a> GsSolution<'a> {
         self.j_2d = j_2d.clone();
     }
 
-    pub fn initialise_plasma_with_point_source_current(&mut self, initial_ip: f64, initial_cur_r: f64, initial_cur_z: f64) {
+    pub fn initialise_plasma_with_quadratic_current_density(&mut self, initial_ip: f64, initial_cur_r: f64, initial_cur_z: f64) -> Result<(), String> {
         // Unpack objects
         let plasma: &Plasma = self.plasma;
         let coils_dynamic: &SensorsDynamic = self.coils_dynamic;
@@ -1554,58 +1733,18 @@ impl<'a> GsSolution<'a> {
             psi_2d_coils = psi_2d_coils + &greens_pf_grid.slice(s![.., .., i_pf]) * pf_currents[i_pf];
         }
 
-        // Initial plasma (single filament)
-        let mut j_2d: Array2<f64> = Array2::zeros((n_z, n_r));
-
-        // Find where to initialise the plasma
         let r: Array1<f64> = plasma.results.get("grid").get("r").unwrap_array1();
-        let r_target: f64 = initial_cur_r;
-        let mut i_r_centre: usize = 0;
-        let mut smallest_diff: f64 = f64::MAX;
-        for (i_r, &value) in r.iter().enumerate() {
-            let diff: f64 = (value - r_target).abs();
-            if diff < smallest_diff {
-                smallest_diff = diff;
-                i_r_centre = i_r;
-            }
-        }
         let z: Array1<f64> = plasma.results.get("grid").get("z").unwrap_array1();
-        let z_target: f64 = initial_cur_z;
-        let mut i_z_centre: usize = 0;
-        let mut smallest_diff: f64 = f64::MAX;
-        for (i_z, &value) in z.iter().enumerate() {
-            let diff: f64 = (value - z_target).abs();
-            if diff < smallest_diff {
-                smallest_diff = diff;
-                i_z_centre = i_z;
-            }
-        }
-
-        // Create a "hill" of current
-        // TODO: this can be improved --> like RT-GSFit initial guess
-        j_2d[(i_z_centre, i_r_centre)] = 3.0;
-
-        j_2d[(i_z_centre - 1, i_r_centre)] = 2.0;
-        j_2d[(i_z_centre + 1, i_r_centre)] = 2.0;
-        j_2d[(i_z_centre, i_r_centre - 1)] = 2.0;
-        j_2d[(i_z_centre, i_r_centre + 1)] = 2.0;
-
-        j_2d[(i_z_centre + 2, i_r_centre)] = 1.0;
-        j_2d[(i_z_centre - 2, i_r_centre)] = 1.0;
-        j_2d[(i_z_centre + 1, i_r_centre + 1)] = 1.0;
-        j_2d[(i_z_centre - 1, i_r_centre + 1)] = 1.0;
-        j_2d[(i_z_centre, i_r_centre + 2)] = 1.0;
-        j_2d[(i_z_centre + 1, i_r_centre - 1)] = 1.0;
-        j_2d[(i_z_centre - 1, i_r_centre - 1)] = 1.0;
-        j_2d[(i_z_centre, i_r_centre - 2)] = 1.0;
-
-        j_2d = j_2d * initial_ip / d_area / 19.0;
+        let vessel_r: Array1<f64> = plasma.results.get("vessel").get("r").unwrap_array1();
+        let vessel_z: Array1<f64> = plasma.results.get("vessel").get("z").unwrap_array1();
+        let j_2d = quadratic_current_density_seed(&r, &z, &vessel_r, &vessel_z, d_area, initial_ip, initial_cur_r, initial_cur_z)?;
 
         // Store in self
         self.j_2d = j_2d;
         self.psi_2d_coils = psi_2d_coils;
-        self.r_mag = r[i_r_centre]; // `r_mag` is not really correct; but as good as we can do for the initial guess
-        self.z_mag = 0.0;
+        self.r_mag = initial_cur_r;
+        self.z_mag = initial_cur_z;
+        Ok(())
     }
 
     /// Calculate the Grad-Shafranov "error"

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -22,33 +22,44 @@ use std::f64::consts::PI;
 use std::sync::Arc;
 
 const MU_0: f64 = physical_constants::VACUUM_MAG_PERMEABILITY;
+const INITIAL_ELLIPSE_BOUNDARY_POINTS: usize = 4096;
 
 /// Create a smooth, axis-aligned quadratic current-density seed.
 ///
 /// The ellipse is centred on the supplied initial magnetic-axis guess. Its
-/// aspect ratio comes from the available radial and vertical extents of the
-/// vessel and computational grid. Both semi-axes are then reduced by the same
-/// factor until every grid point with nonzero current lies inside the vessel.
-/// The discrete current is normalised to `initial_ip` within floating-point
-/// precision.
+/// radial semi-axis is `initial_minor_radius`, and its vertical semi-axis is
+/// `initial_minor_radius * initial_kappa`. These plasma parameters are
+/// independent of the vacuum-vessel shape. The complete sampled ellipse must
+/// lie inside the vessel and computational grid, and no limiter point may lie
+/// inside its support. The discrete current is normalised to `initial_ip`
+/// within floating-point precision.
 fn quadratic_current_density_seed(
     r: &Array1<f64>,
     z: &Array1<f64>,
+    limiter_r: &Array1<f64>,
+    limiter_z: &Array1<f64>,
     vessel_r: &Array1<f64>,
     vessel_z: &Array1<f64>,
     d_area: f64,
     initial_ip: f64,
     initial_cur_r: f64,
     initial_cur_z: f64,
+    initial_minor_radius: f64,
+    initial_kappa: f64,
 ) -> Result<Array2<f64>, String> {
     if r.len() < 2 || z.len() < 2 {
         return Err("quadratic current initialisation requires at least two radial and vertical grid points".to_string());
+    }
+    if limiter_r.len() != limiter_z.len() || limiter_r.is_empty() {
+        return Err("quadratic current initialisation requires matching, nonempty limiter R/Z arrays".to_string());
     }
     if vessel_r.len() != vessel_z.len() || vessel_r.len() < 3 {
         return Err("quadratic current initialisation requires matching vessel R/Z arrays with at least three points".to_string());
     }
     if r.iter()
         .chain(z.iter())
+        .chain(limiter_r.iter())
+        .chain(limiter_z.iter())
         .chain(vessel_r.iter())
         .chain(vessel_z.iter())
         .any(|value| !value.is_finite())
@@ -58,20 +69,21 @@ fn quadratic_current_density_seed(
         || initial_ip == 0.0
         || !initial_cur_r.is_finite()
         || !initial_cur_z.is_finite()
+        || !initial_minor_radius.is_finite()
+        || initial_minor_radius <= 0.0
+        || !initial_kappa.is_finite()
+        || initial_kappa <= 0.0
     {
-        return Err("quadratic current initialisation requires finite geometry, positive cell area, and finite nonzero initial current".to_string());
+        return Err(
+            "quadratic current initialisation requires finite geometry, positive cell area, finite nonzero initial current, positive minor radius, and positive kappa"
+                .to_string(),
+        );
     }
 
-    let vessel_coordinates: Vec<Coord<f64>> = vessel_r
-        .iter()
-        .zip(vessel_z.iter())
-        .map(|(&r_value, &z_value)| Coord { x: r_value, y: z_value })
-        .collect();
-    let vessel_polygon = Polygon::new(LineString::new(vessel_coordinates), vec![]);
-    if !vessel_polygon.contains(&Point::new(initial_cur_r, initial_cur_z)) {
-        return Err(format!(
-            "initial current centre ({initial_cur_r}, {initial_cur_z}) must lie strictly inside the vessel"
-        ));
+    let a_r = initial_minor_radius;
+    let b_z = initial_minor_radius * initial_kappa;
+    if !b_z.is_finite() {
+        return Err("quadratic current initialisation requires a finite vertical semi-axis".to_string());
     }
 
     let min_max = |values: &Array1<f64>| -> (f64, f64) {
@@ -81,54 +93,51 @@ fn quadratic_current_density_seed(
     };
     let (grid_r_min, grid_r_max) = min_max(r);
     let (grid_z_min, grid_z_max) = min_max(z);
-    let (vessel_r_min, vessel_r_max) = min_max(vessel_r);
-    let (vessel_z_min, vessel_z_max) = min_max(vessel_z);
-    let a_r_base = (initial_cur_r - grid_r_min)
-        .min(grid_r_max - initial_cur_r)
-        .min(initial_cur_r - vessel_r_min)
-        .min(vessel_r_max - initial_cur_r);
-    let b_z_base = (initial_cur_z - grid_z_min)
-        .min(grid_z_max - initial_cur_z)
-        .min(initial_cur_z - vessel_z_min)
-        .min(vessel_z_max - initial_cur_z);
-    if !a_r_base.is_finite() || !b_z_base.is_finite() || a_r_base <= 0.0 || b_z_base <= 0.0 {
-        return Err("initial current centre must have positive radial and vertical clearance inside the grid and vessel".to_string());
+    if initial_cur_r - a_r < grid_r_min || initial_cur_r + a_r > grid_r_max || initial_cur_z - b_z < grid_z_min || initial_cur_z + b_z > grid_z_max {
+        return Err("initial current ellipse must lie inside the plasma grid".to_string());
     }
 
-    // For an ellipse scaled by lambda, a grid point is in its support when
-    // s_base < lambda^2. Limit lambda using the nearest point outside the
-    // vessel, so no outside grid-point centre receives nonzero current. A
-    // finite source cell next to the wall can still extend partly outside the
-    // vessel polygon. The edge of this initial J_phi support is not an LCFS;
-    // the first-iteration plasma boundary is found separately from the total
-    // poloidal flux, including the PF-coil contribution.
-    let mut scale_squared: f64 = 1.0;
-    for &z_value in z {
-        for &r_value in r {
-            if !vessel_polygon.contains(&Point::new(r_value, z_value)) {
-                let s_base = ((r_value - initial_cur_r) / a_r_base).powi(2) + ((z_value - initial_cur_z) / b_z_base).powi(2);
-                scale_squared = scale_squared.min(s_base);
-            }
+    // Some readers append discrete tile points to a closed limiter outline, so
+    // the limiter is deliberately treated as a point set rather than a polygon.
+    for (&r_value, &z_value) in limiter_r.iter().zip(limiter_z.iter()) {
+        let s = ((r_value - initial_cur_r) / a_r).powi(2) + ((z_value - initial_cur_z) / b_z).powi(2);
+        if s < 1.0 {
+            return Err("initial current ellipse contains a limiter point".to_string());
         }
     }
-    if !scale_squared.is_finite() || scale_squared <= f64::EPSILON {
-        return Err("vessel geometry leaves no finite quadratic-current support around the initial centre".to_string());
+
+    let vessel_coordinates: Vec<Coord<f64>> = vessel_r
+        .iter()
+        .zip(vessel_z.iter())
+        .map(|(&r_value, &z_value)| Coord { x: r_value, y: z_value })
+        .collect();
+    let vessel_polygon = Polygon::new(LineString::new(vessel_coordinates), vec![]);
+    let ellipse_coordinates: Vec<Coord<f64>> = (0..=INITIAL_ELLIPSE_BOUNDARY_POINTS)
+        .map(|i_point| {
+            let theta = 2.0 * PI * i_point as f64 / INITIAL_ELLIPSE_BOUNDARY_POINTS as f64;
+            Coord {
+                x: initial_cur_r + a_r * theta.cos(),
+                y: initial_cur_z + b_z * theta.sin(),
+            }
+        })
+        .collect();
+    let ellipse_polygon = Polygon::new(LineString::new(ellipse_coordinates), vec![]);
+    if !vessel_polygon.contains(&ellipse_polygon) {
+        return Err("initial current ellipse must lie strictly inside the vessel".to_string());
     }
 
-    // If operational experience shows that user control is needed, an optional
-    // `initial_current_scale` in (0, 1] can multiply this automatic scale. Such
-    // a factor would preserve the centre and aspect ratio, only shrink the
-    // support, and leave the total current unchanged after normalisation.
-    let scale = scale_squared.sqrt();
-    let a_r = a_r_base * scale;
-    let b_z = b_z_base * scale;
+    // This edge is the support of the initial J_phi guess, not an LCFS; the
+    // first-iteration plasma boundary is found separately from the total
+    // poloidal flux, including PF-coil flux.
     let mut shape = Array2::zeros((z.len(), r.len()));
     for (i_z, &z_value) in z.iter().enumerate() {
         for (i_r, &r_value) in r.iter().enumerate() {
-            if vessel_polygon.contains(&Point::new(r_value, z_value)) {
-                let s = ((r_value - initial_cur_r) / a_r).powi(2) + ((z_value - initial_cur_z) / b_z).powi(2);
-                shape[(i_z, i_r)] = (1.0 - s).max(0.0);
+            let s = ((r_value - initial_cur_r) / a_r).powi(2) + ((z_value - initial_cur_z) / b_z).powi(2);
+            let shape_value = (1.0 - s).max(0.0);
+            if shape_value > 0.0 && !vessel_polygon.contains(&Point::new(r_value, z_value)) {
+                return Err("quadratic current support contains a grid point outside the vessel".to_string());
             }
+            shape[(i_z, i_r)] = shape_value;
         }
     }
 
@@ -136,71 +145,136 @@ fn quadratic_current_density_seed(
     if !shape_integral.is_finite() || shape_integral <= 0.0 {
         return Err("quadratic current initialisation has empty support on the plasma grid".to_string());
     }
-    return Ok(shape * (initial_ip / shape_integral));
+    let normalisation = initial_ip / shape_integral;
+    if !normalisation.is_finite() {
+        return Err("quadratic current initialisation requires a finite current-density normalisation".to_string());
+    }
+    let j_2d = shape * normalisation;
+    let achieved_current = j_2d.sum() * d_area;
+    let relative_error = (achieved_current - initial_ip).abs() / initial_ip.abs();
+    if j_2d.iter().any(|value| !value.is_finite()) || !relative_error.is_finite() || relative_error > 1.0e-10 {
+        return Err("quadratic current initialisation could not produce a finite, normalised current density".to_string());
+    }
+    return Ok(j_2d);
 }
 
 #[cfg(test)]
 mod tests {
     use super::quadratic_current_density_seed;
-    use geo::{Contains, Coord, LineString, Point, Polygon};
     use ndarray::{Array1, array};
 
     #[test]
-    fn quadratic_current_seed_is_normalised_smooth_and_inside_vessel() {
+    fn quadratic_current_seed_is_normalised_and_uses_explicit_shape() {
         let r = Array1::linspace(1.0, 3.0, 9);
-        let z = Array1::linspace(-1.0, 1.0, 9);
-        let vessel_r = array![2.0, 3.0, 2.0, 1.0, 2.0];
-        let vessel_z = array![1.0, 0.0, -1.0, 0.0, 1.0];
+        let z = Array1::linspace(-1.5, 1.5, 13);
+        let limiter_r = array![0.8, 3.2, 3.2, 0.8, 0.8];
+        let limiter_z = array![-1.7, -1.7, 1.7, 1.7, -1.7];
+        let vessel_r = array![0.75, 3.25, 3.25, 0.75, 0.75];
+        let vessel_z = array![-1.75, -1.75, 1.75, 1.75, -1.75];
         let d_area = (r[1] - r[0]) * (z[1] - z[0]);
         let initial_ip = 120_000.0;
 
-        let j_2d = quadratic_current_density_seed(&r, &z, &vessel_r, &vessel_z, d_area, initial_ip, 2.0, 0.0).unwrap();
+        let j_2d = quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r, &vessel_z, d_area, initial_ip, 2.0, 0.0, 0.5, 2.0).unwrap();
 
         assert!((j_2d.sum() * d_area - initial_ip).abs() < 1.0e-10 * initial_ip);
-        assert!(j_2d[(4, 4)] > j_2d[(4, 5)]);
-        assert!(j_2d[(4, 5)] > j_2d[(4, 6)]);
-        assert!((j_2d[(4, 5)] / j_2d[(4, 4)] - 0.875).abs() < 1.0e-12);
-        assert!((j_2d[(4, 6)] / j_2d[(4, 4)] - 0.5).abs() < 1.0e-12);
+        assert!((j_2d[(6, 5)] / j_2d[(6, 4)] - 0.75).abs() < 1.0e-12);
+        assert!((j_2d[(7, 4)] / j_2d[(6, 4)] - 0.9375).abs() < 1.0e-12);
+        assert_eq!(j_2d[(6, 6)], 0.0);
+        assert_eq!(j_2d[(10, 4)], 0.0);
+    }
 
-        let vessel_coordinates: Vec<Coord<f64>> = vessel_r
-            .iter()
-            .zip(vessel_z.iter())
-            .map(|(&r_value, &z_value)| Coord { x: r_value, y: z_value })
-            .collect();
-        let vessel_polygon = Polygon::new(LineString::new(vessel_coordinates), vec![]);
-        for (i_z, &z_value) in z.iter().enumerate() {
-            for (i_r, &r_value) in r.iter().enumerate() {
-                if j_2d[(i_z, i_r)] != 0.0 {
-                    assert!(vessel_polygon.contains(&Point::new(r_value, z_value)));
-                }
-            }
-        }
+    #[test]
+    fn quadratic_current_seed_is_independent_of_vessel_shape() {
+        let r = Array1::linspace(1.0, 3.0, 17);
+        let z = Array1::linspace(-1.5, 1.5, 25);
+        let limiter_r = array![0.8, 3.2, 3.2, 0.8, 0.8];
+        let limiter_z = array![-1.7, -1.7, 1.7, 1.7, -1.7];
+        let vessel_r_1 = array![0.75, 3.25, 3.25, 0.75, 0.75];
+        let vessel_z_1 = array![-1.75, -1.75, 1.75, 1.75, -1.75];
+        let vessel_r_2 = array![0.7, 3.3, 3.3, 2.6, 0.7, 0.7];
+        let vessel_z_2 = array![-1.8, -1.8, 1.8, 1.65, 1.8, -1.8];
+        let d_area = (r[1] - r[0]) * (z[1] - z[0]);
+
+        let seed_1 = quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r_1, &vessel_z_1, d_area, 100_000.0, 2.0, 0.0, 0.5, 2.0).unwrap();
+        let seed_2 = quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r_2, &vessel_z_2, d_area, 100_000.0, 2.0, 0.0, 0.5, 2.0).unwrap();
+
+        assert_eq!(seed_1, seed_2);
     }
 
     #[test]
     fn quadratic_current_seed_preserves_negative_current_sign() {
         let r = Array1::linspace(1.0, 3.0, 9);
-        let z = Array1::linspace(-1.0, 1.0, 9);
-        let vessel_r = array![0.9, 3.1, 3.1, 0.9, 0.9];
-        let vessel_z = array![-1.1, -1.1, 1.1, 1.1, -1.1];
+        let z = Array1::linspace(-1.5, 1.5, 13);
+        let limiter_r = array![0.8, 3.2, 3.2, 0.8, 0.8];
+        let limiter_z = array![-1.7, -1.7, 1.7, 1.7, -1.7];
+        let vessel_r = array![0.75, 3.25, 3.25, 0.75, 0.75];
+        let vessel_z = array![-1.75, -1.75, 1.75, 1.75, -1.75];
         let d_area = (r[1] - r[0]) * (z[1] - z[0]);
 
-        let j_2d = quadratic_current_density_seed(&r, &z, &vessel_r, &vessel_z, d_area, -80_000.0, 2.0, 0.0).unwrap();
+        let j_2d = quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r, &vessel_z, d_area, -80_000.0, 2.0, 0.0, 0.5, 2.0).unwrap();
 
         assert!((j_2d.sum() * d_area + 80_000.0).abs() < 1.0e-8);
         assert!(j_2d.iter().all(|value| *value <= 0.0));
     }
 
     #[test]
-    fn quadratic_current_seed_rejects_centre_outside_vessel() {
+    fn quadratic_current_seed_rejects_limiter_point_inside_support() {
         let r = Array1::linspace(1.0, 3.0, 9);
-        let z = Array1::linspace(-1.0, 1.0, 9);
-        let vessel_r = array![1.5, 2.5, 2.5, 1.5, 1.5];
-        let vessel_z = array![-0.5, -0.5, 0.5, 0.5, -0.5];
+        let z = Array1::linspace(-1.5, 1.5, 13);
+        let limiter_r = array![0.8, 3.2, 3.2, 0.8, 0.8, 2.25];
+        let limiter_z = array![-1.7, -1.7, 1.7, 1.7, -1.7, 0.0];
+        let vessel_r = array![0.75, 3.25, 3.25, 0.75, 0.75];
+        let vessel_z = array![-1.75, -1.75, 1.75, 1.75, -1.75];
 
-        let error = quadratic_current_density_seed(&r, &z, &vessel_r, &vessel_z, 0.0625, 10_000.0, 1.25, 0.0).unwrap_err();
+        let error = quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r, &vessel_z, 0.0625, 10_000.0, 2.0, 0.0, 0.5, 2.0).unwrap_err();
+
+        assert!(error.contains("contains a limiter point"));
+    }
+
+    #[test]
+    fn quadratic_current_seed_rejects_ellipse_outside_vessel() {
+        let r = Array1::linspace(1.0, 3.0, 9);
+        let z = Array1::linspace(-1.5, 1.5, 13);
+        let limiter_r = array![0.8, 3.2, 3.2, 0.8, 0.8];
+        let limiter_z = array![-1.7, -1.7, 1.7, 1.7, -1.7];
+        let vessel_r = array![1.75, 3.25, 3.25, 1.75, 1.75];
+        let vessel_z = array![-1.75, -1.75, 1.75, 1.75, -1.75];
+
+        let error = quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r, &vessel_z, 0.0625, 10_000.0, 2.0, 0.0, 0.5, 2.0).unwrap_err();
 
         assert!(error.contains("strictly inside the vessel"));
+    }
+
+    #[test]
+    fn quadratic_current_seed_rejects_nonfinite_normalisation() {
+        let r = Array1::linspace(1.0, 3.0, 9);
+        let z = Array1::linspace(-1.5, 1.5, 13);
+        let limiter_r = array![0.8, 3.2, 3.2, 0.8, 0.8];
+        let limiter_z = array![-1.7, -1.7, 1.7, 1.7, -1.7];
+        let vessel_r = array![0.75, 3.25, 3.25, 0.75, 0.75];
+        let vessel_z = array![-1.75, -1.75, 1.75, 1.75, -1.75];
+
+        let error = quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r, &vessel_z, 0.0625, f64::MAX, 2.0, 0.0, 0.5, 2.0).unwrap_err();
+
+        assert!(error.contains("finite current-density normalisation"));
+    }
+
+    #[test]
+    fn quadratic_current_seed_rejects_nonpositive_shape_parameters() {
+        let r = Array1::linspace(1.0, 3.0, 9);
+        let z = Array1::linspace(-1.5, 1.5, 13);
+        let limiter_r = array![0.8, 3.2, 3.2, 0.8, 0.8];
+        let limiter_z = array![-1.7, -1.7, 1.7, 1.7, -1.7];
+        let vessel_r = array![0.75, 3.25, 3.25, 0.75, 0.75];
+        let vessel_z = array![-1.75, -1.75, 1.75, 1.75, -1.75];
+
+        let minor_radius_error =
+            quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r, &vessel_z, 0.0625, 10_000.0, 2.0, 0.0, 0.0, 2.0).unwrap_err();
+        let kappa_error =
+            quadratic_current_density_seed(&r, &z, &limiter_r, &limiter_z, &vessel_r, &vessel_z, 0.0625, 10_000.0, 2.0, 0.0, 0.5, 0.0).unwrap_err();
+
+        assert!(minor_radius_error.contains("positive minor radius"));
+        assert!(kappa_error.contains("positive kappa"));
     }
 }
 
@@ -670,7 +744,13 @@ impl<'a> GsSolution<'a> {
         self.passive_dof_values = Array1::zeros(n_passive_dof);
 
         // Initialise plasma with a smooth quadratic current-density distribution.
-        if let Err(reason) = self.initialise_plasma_with_quadratic_current_density(plasma.initial_ip, plasma.initial_cur_r, plasma.initial_cur_z) {
+        if let Err(reason) = self.initialise_plasma_with_quadratic_current_density(
+            plasma.initial_ip,
+            plasma.initial_cur_r,
+            plasma.initial_cur_z,
+            plasma.initial_minor_radius,
+            plasma.initial_kappa,
+        ) {
             self.set_to_failed_time_slice();
             self.error_state = Some(Error::InvalidInitialCurrent(reason));
             println!("{:?}", self.error_state.as_ref().unwrap());
@@ -1722,7 +1802,14 @@ impl<'a> GsSolution<'a> {
         self.j_2d = j_2d.clone();
     }
 
-    pub fn initialise_plasma_with_quadratic_current_density(&mut self, initial_ip: f64, initial_cur_r: f64, initial_cur_z: f64) -> Result<(), String> {
+    pub fn initialise_plasma_with_quadratic_current_density(
+        &mut self,
+        initial_ip: f64,
+        initial_cur_r: f64,
+        initial_cur_z: f64,
+        initial_minor_radius: f64,
+        initial_kappa: f64,
+    ) -> Result<(), String> {
         // Unpack objects
         let plasma: &Plasma = self.plasma;
         let coils_dynamic: &SensorsDynamic = self.coils_dynamic;
@@ -1743,9 +1830,24 @@ impl<'a> GsSolution<'a> {
 
         let r: Array1<f64> = plasma.results.get("grid").get("r").unwrap_array1();
         let z: Array1<f64> = plasma.results.get("grid").get("z").unwrap_array1();
+        let limiter_r: Array1<f64> = plasma.results.get("limiter").get("limit_pts").get("r").unwrap_array1();
+        let limiter_z: Array1<f64> = plasma.results.get("limiter").get("limit_pts").get("z").unwrap_array1();
         let vessel_r: Array1<f64> = plasma.results.get("vessel").get("r").unwrap_array1();
         let vessel_z: Array1<f64> = plasma.results.get("vessel").get("z").unwrap_array1();
-        let j_2d = quadratic_current_density_seed(&r, &z, &vessel_r, &vessel_z, d_area, initial_ip, initial_cur_r, initial_cur_z)?;
+        let j_2d = quadratic_current_density_seed(
+            &r,
+            &z,
+            &limiter_r,
+            &limiter_z,
+            &vessel_r,
+            &vessel_z,
+            d_area,
+            initial_ip,
+            initial_cur_r,
+            initial_cur_z,
+            initial_minor_radius,
+            initial_kappa,
+        )?;
 
         // Store in self
         self.j_2d = j_2d;

--- a/rust/gsfit_rs/src/grad_shafranov/mod.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/mod.rs
@@ -10,6 +10,7 @@ pub use gs_solution::GsSolution;
 // Define the possible **external** failures this module can produce
 #[derive(Debug)]
 pub enum Error {
+    InvalidInitialCurrent(String),
     NoBoundaryFound { no_xpt_reason: String, no_limit_point_reason: String },
     NoMagneticAxisFound,
     MaxIterReached,

--- a/rust/gsfit_rs/src/plasma.rs
+++ b/rust/gsfit_rs/src/plasma.rs
@@ -34,6 +34,8 @@ pub struct Plasma {
     pub initial_ip: f64,
     pub initial_cur_r: f64,
     pub initial_cur_z: f64,
+    pub initial_minor_radius: f64,
+    pub initial_kappa: f64,
 }
 
 // Python accessible methods
@@ -55,6 +57,11 @@ impl Plasma {
     /// * `vessel_z` - vessel vertical points (1d array), [metre]
     /// * `p_prime_source_function` - pressure source function (a Rust implementation, initialised in Python)
     /// * `ff_prime_source_function` - ff_prime source function (a Rust implementation, initialised in Python)
+    /// * `initial_ip` - initial total plasma current, [ampere]
+    /// * `initial_cur_r` - radial centre of the initial current distribution, [metre]
+    /// * `initial_cur_z` - vertical centre of the initial current distribution, [metre]
+    /// * `initial_minor_radius` - radial semi-axis of the initial current distribution, [metre]
+    /// * `initial_kappa` - elongation of the initial current distribution, [dimensionless]
     ///
     /// # Returns
     /// * `self` - a new instance of the Plasma struct
@@ -78,6 +85,8 @@ impl Plasma {
         initial_ip: f64,
         initial_cur_r: f64,
         initial_cur_z: f64,
+        initial_minor_radius: f64,
+        initial_kappa: f64,
     ) -> Self {
         // Change Python types into Rust types
         let psi_n_ndarray: Array1<f64> = psi_n.to_owned_array();
@@ -241,6 +250,8 @@ impl Plasma {
             initial_ip,
             initial_cur_r,
             initial_cur_z,
+            initial_minor_radius,
+            initial_kappa,
         }
     }
 


### PR DESCRIPTION
## Summary

- replace the hard-coded 13-cell plasma-current hill with a smooth, axis-aligned quadratic current-density seed
- centre the seed on the existing `initial_cur_r` and `initial_cur_z` values
- choose its aspect ratio and maximum support automatically from the grid and vessel geometry
- normalise the discrete current to `initial_ip` within floating-point precision
- report invalid initial-current geometry as a failed time slice instead of panicking

No new Python or JSON settings are introduced, and the seed does not assume a pressure or source-function profile.

## Motivation

The compact current hill can produce a spiky initial flux pattern and make the first boundary search unnecessarily difficult. In the synthetic `gsfit_rs.self_test` case, the released 0.0.9 wheel reports `NoBoundaryFound`, while this branch finds a solution in two iterations with `gs_error=0.270983376884859184`. This is a focused regression result, not a claim of a general speed-up or guaranteed convergence for all inputs.

This work follows the initial-current discussion in #108.

## Geometry and interpretation

The seed is

```text
J_phi(R, Z) = C * max(1 - ((R - R0) / a)^2 - ((Z - Z0) / b)^2, 0)
```

where `C` is chosen from the discrete current integral. The automatically selected semi-axes are reduced together until every grid-point centre carrying non-zero current lies strictly inside the vessel polygon.

Containment is evaluated at grid-point centres. A finite source cell adjacent to the wall can therefore extend partly outside the vessel polygon. Also, the edge of the quadratic `J_phi` support is not an LCFS: the first-iteration plasma boundary is determined separately from the total poloidal flux, including the PF-coil contribution.

If operational experience later shows that explicit size control is useful, an optional `initial_current_scale` in `(0, 1]` could multiply the automatic scale while preserving the centre, aspect ratio, containment rule, and total-current normalisation. This PR deliberately keeps the current interface unchanged.

## Validation

- `cargo test --release --manifest-path rust/Cargo.toml --package gsfit_rs --lib -- --show-output`: 37 passed
- `maturin build --release`: `Finished release profile [optimized]`
- `python -m pytest -q tests/test_01_initialisation.py`: passed
- installed-wheel `gsfit_rs.self_test`: `solution_found=true`, `n_iter=2`, `gs_error=0.270983376884859184`
- invalid `initial_ip=0` integration check: returned `InvalidInitialCurrent` and a failed time slice without a Rust/Python panic
- `cargo fmt --check` and `git diff --check`: passed

