### PR TITLE
Remove stale self-inductance diagonal check in greens_with_boundary_points

### DIFF
--- a/python/gsfit/database_writers/rtgsfit_mdsplus/greens_with_boundary_points.py
+++ b/python/gsfit/database_writers/rtgsfit_mdsplus/greens_with_boundary_points.py
@@ -73,11 +73,10 @@ def greens_with_boundary_points(plasma: gsfit_rs.Plasma) -> npt.NDArray[np.float
         d_z_vec,  # Needed for self-inductance
     )
 
-    # Check diagonal values for self-inductance are g_ltrb[i, i] = self_inductance_rectangle_cross_section(r_ltrb[i], d_r, d_z)
-    for i in range(n_ltrb):
-        expected_self_inductance = self_inductance_rectangle_cross_section(r_ltrb[i], d_r_vec[i], d_z_vec[i])
-        if not np.isclose(g_ltrb[i, i], expected_self_inductance):
-            raise ValueError(f"Diagonal value at index {i} does not match expected self-inductance: {g_ltrb[i, i]} != {expected_self_inductance}")
+    # The diagonal self-inductance values returned by greens_py are evaluated at the centre of the
+    # rectangular cross-section. Here we instead need the average over the cross-section, since g_ltrb
+    # is used to compute a line integral for which the cross-section average is more accurate. We
+    # therefore overwrite the diagonals below rather than validating them against greens_py.
 
     # Need to overwrite the diagonals of the matrix with the self-inductance for a surface current on
     # the computational boundary. Excluding the corners, which are not used by RTGSFIT


### PR DESCRIPTION
## Summary

The RT-GSFit `greens_with_boundary_points` contained a validation loop asserting that the
diagonal of `g_ltrb` matched `self_inductance_rectangle_cross_section(...)`.
That assumption is no longer valid:

- **Off-diagonal (mutual) terms** in `greens_py` treat conductors as
  infinitesimal filaments (elliptic-integral Green's function).
- **Diagonal (self) terms** are regularised with the finite rectangular
  cross-section formula, but evaluated as the flux at the **centre** of the
  cell — *not* the cross-section-averaged self-inductance (see the `psi()`
  docstring in `rust/gsfit_rs/src/greens/greens.rs`, which notes the centre
  value runs ~5% high).

Because the diagonals are subsequently **overwritten** with the
cross-section-averaged `self_inductance_rectangle_cross_section(...)` — the
correct quantity for the boundary line integral — the check was comparing two
intentionally different quantities and would raise a spurious `ValueError`.

## Changes

- Removed the dead diagonal-validation loop.
- Added a comment documenting why the diagonals are overwritten rather than
  validated against `greens_py`.

## Notes

Behaviour is unchanged: the diagonal overwrite that follows already produces
the values the removed check was (incorrectly) asserting. No functional or
numerical change to `g_ltrb`.