### PR TITLE
Faster offline reconstruction at unchanged accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ venv_gsfit/
 
 # Ruff autoforamtting
 .ruff_cache
+benchmark_results/

--- a/documentation/performance/2026-09-offline-throughput.md
+++ b/documentation/performance/2026-09-offline-throughput.md
@@ -1,0 +1,129 @@
+# Offline reconstruction throughput, September 2026
+
+This note documents the measurements behind the pull request "Faster offline reconstruction at unchanged accuracy". It records what a GSFit "run" consists of, where the time went, what was changed, and the before/after evidence on public workloads.
+
+## 1. What a run consists of
+
+`Gsfit.run()` performs, in order:
+
+| Phase | What happens | Scales with |
+| --- | --- | --- |
+| `setup_objects` | Database reader builds the Rust objects. For ST40 this includes the passive eigenmode decomposition (finite-size mutual inductance between all vessel filaments). | vessel filaments squared |
+| `calculate_greens` | Green's tables between coils, passives and the plasma grid, and between every current source and every sensor. | grid points, filaments, sensors, passive degrees of freedom |
+| `inverse_solver_rust` | Picard iteration per time-slice (parallel over slices with rayon), then the equilibrium post-processor and the sensor post-processing. | time-slices, iterations, grid points |
+| `write_results_to_mdsplus` | Maps results to the MDSplus tree layout (and writes to MDSplus inside Tokamak Energy's network). | output size |
+
+The default ST40 settings reconstruct `arange(10 ms, 250 ms, 0.5 ms)` = 480 time-slices on an 81 x 161 grid with 7 PF coils, 8 passive conductors (538 filaments; the IVC with 15 eigenmode degrees of freedom) and 59 magnetic sensors. The per-slice Picard iteration converges in about 14 iterations to `gs_error = 5e-6`.
+
+A reported "about ten minutes" for a post-shot run was therefore compared with the sum of setup, Green's tables and the 480-slice solve on public data, not with a single per-slice update. MDSplus reads and writes are not part of the public workloads and were not measured.
+
+## 2. Workloads and acceptance criteria (frozen before tuning)
+
+All workloads are public and run without Tokamak Energy's network:
+
+* **ST40 mock, 31 slices**: real ST40 pulse 12050 magnetics from the mocked MDSplus trees in `tests/test_02_delta_z_shift_greater_than_d_z/data` (31 samples in a 0.3 ms window around 130 ms), default settings. Representative of the standard ST40 configuration (passives with eigenmodes, all sensor types).
+* **ST40 mock, 480 slices**: the same window tiled to the default workflow length, to measure a full-length run.
+* **MAST-U FreeGSNKE example 02**: `examples/example_02__mastu__freegsnke_data.ipynb` (synthetic magnetics from FreeGSNKE, 65 x 129 grid, no passives), magnetics-only solve and the isoflux re-solve.
+* **MAST-U FreeGSNKE example 07**: tensioned cubic B-spline source functions.
+* **Rust unit tests, doc tests, `pytest tests/`, `mypy`, `ty`**.
+
+Acceptance: identical requested diagnostics, grid, tolerances and iteration limits; per time-slice, the flux map, boundary, magnetic axis, Ip, fitted coefficients, chi_mag, profiles and the iteration count are compared with the reference build. Changes at the floating-point rounding level (about 1e-10 relative) are accepted; any change in convergence outcome or iteration count is not.
+
+## 3. Where the time went (reference build, ST40 mock, 31 slices, 8 threads, Apple M4)
+
+| Phase | Time | Cause |
+| --- | --- | --- |
+| passives setup | 20.8 s | finite-size mutual inductance of 388 IVC filaments, serial, each 100 x 100 sub-filament block built through the thread pool |
+| Green's with passives | 27.5 s | plasma-grid and sensor Green's tables recomputed for every passive degree of freedom (15x for the IVC); Rogowski virtual probes rebuilt per degree of freedom |
+| Green's with coils, plasma | 5.1 s | |
+| solve, 31 slices | 12.8 s | per Picard iteration: dense Green's matrix product 61%, boundary flood fill 14%, stationary-point search 9%, per-slice table reorganisation 8% |
+
+## 4. What changed
+
+1. **Passive Green's tables once per passive** (commit "Calculate passive Green's tables once per passive"): the filament tables are calculated once and contracted with each degree of freedom; the mutual-inductance quadrature runs in parallel with sequential inner blocks. Bitwise identical.
+2. **Per-run tables shared across slices** (commit "Share per-run solver tables"): reorganised Green's tables, inside-vessel mask and static sensor tables built once per run instead of per slice or per iteration; dense edge arrays in the stationary-point search. Bitwise identical.
+3. **FFT convolution along z** (commit "Evaluate the plasma Green's convolution with FFTs along z"): the plasma contribution to psi and its derivatives is a convolution along the uniform z axis for every radial pair, evaluated with real FFTs instead of a 3 GFLOP dense product per iteration. Same double sum, different rounding order.
+4. **Per-iteration and per-slice reuse** (commit "Reuse per-iteration and per-slice quantities"): source-function basis functions evaluated once per iteration, PF coil fields once per slice, boolean grid in the flood fill. Bitwise identical.
+5. **Parallel post-processing** (commit "Post-process the time-slices in parallel"): the boundary contour, flux surfaces, profiles and scrape-off-layer legs are calculated in parallel over the slices. Bitwise identical.
+6. **Stationary-point search** (commit "Skip cells without edge crossings"): cells with no zero crossing on any edge are skipped before any allocation. Bitwise identical.
+7. **Robustness** (commit "Allow a sensor type with no included sensors"): excluding every bp probe or every flux loop no longer panics; regression test added.
+
+The reference for "bitwise identical" is the ST40 mock workload (2 and 31 slices) compared with `compare_results.py` after each commit; the FFT commit is the only one which changes results, at the rounding level.
+
+## 5. Results
+
+### 5.1 Timing (medians of 3 alternating runs; the 480-slice runs once each)
+
+| Metric and workload | Before (s) | After (s) | Improvement | n |
+| --- | --- | --- | --- | --- |
+| ST40 mock, 31 slices, total (setup + Green's + solve + map) | 71.00 | 15.78 | 4.5x | 3/3 |
+|   setup_objects | 21.73 | 8.99 | 2.4x | 3/3 |
+|   calculate_greens | 34.33 | 4.86 | 7.1x | 3/3 |
+|   inverse_solver (31 slices incl. post-processing) | 15.24 | 1.91 | 8.0x | 3/3 |
+| ST40 mock, 480 slices (default workflow length), total | 293.43 | 38.70 | 7.6x | 1/1 |
+|   inverse_solver (480 slices) | 233.81 | 26.55 | 8.8x | 1/1 |
+| MAST-U FreeGSNKE example 02, GSFit part (setup + Green's + 2 solves) | 4.45 | 3.07 | 1.5x | 3/3 |
+|   inverse_solver (1 slice) | 0.51 | 0.19 | 2.8x | 3/3 |
+| Notebook example 02 end to end (incl. FreeGSNKE forward solve, plots) | 12.11 | 9.80 | 1.2x | 3/3 |
+| Notebook example 07 end to end (B-spline source functions) | 11.10 | 8.15 | 1.4x | 3/3 |
+
+The "total" rows exclude the Python import and the result dump of the benchmark script. Reference: upstream `main` at `2f6fd0c`; candidate: this branch at `39bd7b3` (the later commits change tests, warnings and documentation only). For the ST40 workloads the solver phase is now a minority of the run; the remaining setup cost is dominated by the finite-size mutual-inductance quadrature of the vessel filaments (parallel, but still 100 x 100 elliptic-integral blocks per filament pair) and the Green's tables of the PF coils.
+
+### 5.2 Accuracy
+
+Accuracy (candidate vs reference, first repeat):
+| Workload | psi max rel diff | boundary max abs diff (m) | Ip max rel diff | chi_mag max rel diff | n_iter identical | converged before/after |
+| --- | --- | --- | --- | --- | --- | --- |
+| ST40 mock 31 slices | 1.8e-11 | 1.9e-10 | 2.0e-12 | 1.1e-10 | True | 31/31 vs 31/31 |
+| ST40 mock 480 slices | 1.4e-06 | 3.1e-06 | 1.3e-07 | 3.1e-06 | False | 480/480 vs 480/480 |
+| MAST-U example 02 (magnetics) | 9.7e-15 | 2.9e-14 | 3.9e-16 | 6.2e-13 | True | 1/1 vs 1/1 |
+| MAST-U example 02 (with isoflux) | 5.0e-15 | 2.7e-14 | 3.9e-16 | 1.1e-13 | True | 1/1 vs 1/1 |
+| MAST-U example 07 (B-splines) | 6.6e-04 | 5.9e-02 | 1.5e-05 | 3.0e-03 | False | 1/1 vs 1/1 |
+
+The "boundary max abs diff" column compares the boundary outlines point by point; for example 07 the two outlines have different point counts and start points because the bounding x-point differs (see below), so that entry measures ordering, not distance. The extents of the two outlines agree to 1e-4 m except for the upper boundary (1.099 m vs 1.134 m), which is the x-point alternation described below.
+
+* ST40 mock, 31 slices: rounding-level agreement on every slice, identical iteration counts.
+* ST40 mock, 480 slices: 479 of 480 slices agree to 3e-11 relative in flux. Slice 64 converged on the reference build at iteration 13 with `gs_error = 4.99999999e-6`, i.e. within rounding of the 5e-6 tolerance, and on this branch at iteration 14; that slice differs by 1.3e-6 relative, the tolerance itself.
+* MAST-U example 02: 1e-14 (bitwise apart from the last digits), with and without the isoflux constraints.
+* MAST-U example 07 (tensioned cubic B-splines, 11 p' degrees of freedom, near double null): the two builds converge along different Picard paths (16 vs 26 iterations) to solutions 3.5e-4 apart in flux, with Ip within 1.5e-5 relative and chi_mag within 0.3%. This case is path-sensitive on the reference build itself: scaling every fit weight by (1 + 1e-14) changes the reference's iteration count to 19, by (1 + 1e-12) to 21, by (1 + 1e-10) to 12, with flux differences of 4e-5 to 1.5e-4 and the same alternation between the upper and lower x-point as the bounding point. The difference on this branch is of that nature (the FFT commit changes floating-point rounding), not a change of the algorithm; every other commit is bitwise identical to its predecessor on this case.
+
+
+## 6. Robustness matrix (ST40 mock, default settings unless stated)
+
+| Case | Before (upstream main) | After (this branch) |
+| --- | --- | --- |
+| nominal, 3 slices | 3/3 converged, [14, 14, 14] iterations | 3/3 converged, [14, 14, 14] iterations |
+| initial Ip = 0 | 0/1 converged (`InvalidInitialCurrent`) | 0/1 converged (`InvalidInitialCurrent`) |
+| initial Ip = -425 kA | 0/1 converged (`NoStationaryPointsFound, Warning:`) | 0/1 converged (`NoStationaryPointsFound, Warning:`) |
+| initial current ellipse outside the vessel (r_cur = 0.95 m) | 0/1 converged (`InvalidInitialCurrent`) | 0/1 converged (`InvalidInitialCurrent`) |
+| initial ellipse far off axis (r_cur = 0.30 m, z_cur = 0.45 m, a = 0.08 m) | 0/1 converged (`InvalidInitialCurrent`) | 0/1 converged (`InvalidInitialCurrent`) |
+| n_iter_max = 3 | 0/1 converged (`MaxIterReached`) | 0/1 converged (`MaxIterReached`) |
+| gs_error = 1e-9 | 1/1 converged, [24] iterations | 1/1 converged, [24] iterations |
+| no bp probes included | crash: `PanicException` | 1/1 converged, [13] iterations |
+| no flux loops included | crash: `PanicException` | 1/1 converged, [14] iterations |
+| only 4 bp probes and 2 flux loops | 1/1 converged, [15] iterations | 1/1 converged, [15] iterations |
+| coarse grid 61 x 121 | 1/1 converged, [13] iterations | 1/1 converged, [13] iterations |
+| fine grid 81 x 321 | 1/1 converged, [14] iterations | 1/1 converged, [14] iterations |
+| vertical feedback disabled | 0/1 converged (`MaxIterReached`) | 0/1 converged (`MaxIterReached`) |
+| p' with 4 and ff' with 3 polynomial degrees of freedom | 0/1 converged (`NoStationaryPointsFound`) | 0/1 converged (`NoStationaryPointsFound`) |
+
+All outcomes, error classes and iteration counts are unchanged except the two cases which crashed before and now run; in the converging cases Ip agrees to better than 2e-12 relative. The remaining failures are pre-existing behaviour of the reconstruction algorithm (a poor initial guess is rejected by the initial-current validation, and the negative-current, vertical-feedback-off and higher-order source-function cases do not converge on this ST40 slice) and are reported here so that they stay visible.
+
+## 7. Reproduction
+
+```shell
+# candidate: this branch; reference: upstream main 2f6fd0c, each in its own clone and venv
+uv pip install -e ".[dev,with_freegs_and_freegsnke]"   # or: maturin develop --release
+git clone https://github.com/FusionComputingLab/freegsnke.git ~/github/freegsnke   # MAST-U machine description
+B=documentation/performance/benchmarks
+python $B/bench_st40_mock.py --n-time 31 --threads 8 --tag ref      # in the reference clone
+python $B/bench_st40_mock.py --n-time 31 --threads 8 --tag new      # in this clone
+python $B/compare_results.py benchmark_results/st40mock_ref.npz benchmark_results/st40mock_new.npz 1e-9
+python $B/bench_mastu.py --n-time 1 --threads 8 --tag new
+python $B/run_notebook.py examples/example_07__mastu__freegsnke_data__tensioned_cubic_b_spline_test.ipynb --tag new
+python $B/robustness.py --tag new
+```
+
+Both clones must use the same numpy and scipy versions: the FreeGSNKE forward solve which produces the synthetic MAST-U measurements gives values which differ by up to 1e-4 T between numpy 1.26 / scipy 1.15 and numpy 2.5 / scipy 1.18, which then shows up as a 1e-4 relative difference in the reconstruction that has nothing to do with GSFit. The numbers below were taken with numpy 1.26.4 and scipy 1.15.3 in both environments (a first pass with mismatched environments was discarded for that reason).
+
+Hardware for the numbers above: Apple M4 (4 performance and 6 efficiency cores), 16 GiB, macOS 26.5, Rust 1.98.1, Python 3.13, `RAYON_NUM_THREADS=8`, release profile (`lto = true`, `codegen-units = 1`). The machine was shared with other work; runs alternated between reference and candidate and medians of three are reported. These are not measurements on Tokamak Energy's hardware.

--- a/documentation/performance/benchmarks/bench_mastu.py
+++ b/documentation/performance/benchmarks/bench_mastu.py
@@ -1,0 +1,145 @@
+"""MAST-U FreeGSNKE synthetic benchmark (reproduces examples/example_02 without plotting).
+
+Phase timing: FreeGSNKE forward solve (not GSFit), then GSFit setup, Greens, inverse solve,
+result mapping, plus the isoflux re-solve from the notebook's section 2.3.
+Usage: bench_mastu.py --n-time 2 --threads 8 --tag baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import benchlib
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--n-time", type=int, default=2)
+parser.add_argument("--threads", type=int, default=8)
+parser.add_argument("--tag", default="run")
+parser.add_argument("--out", default=str(HERE.parent.parent.parent / "benchmark_results"))
+parser.add_argument("--repo", default=str(HERE.parent.parent.parent))
+parser.add_argument("--no-isoflux", action="store_true")
+parser.add_argument("--perturb-psi", type=float, default=0.0, help="scale the FreeGSNKE plasma flux by (1 + perturb_psi) after the forward solve; a rounding-sensitivity control")
+parser.add_argument("--perturb-weights", type=float, default=0.0, help="scale every sensor fit weight by (1 + perturb_weights); a rounding-sensitivity control")
+parser.add_argument("--perturb", type=float, default=0.0, help="scale every coil current by (1 + perturb) before the forward solve; a rounding-sensitivity control")
+args = parser.parse_args()
+os.environ["RAYON_NUM_THREADS"] = str(args.threads)
+repo = Path(args.repo)
+out_dir = Path(args.out)
+
+import numpy as np
+
+timer = benchlib.PhaseTimer()
+import gsfit_rs
+from freegsnke import GSstaticsolver
+from freegsnke import build_machine
+from freegsnke import equilibrium_update
+from freegsnke.jtor_update import ConstrainPaxisIp
+from gsfit import Gsfit
+
+timer.mark("import")
+
+cfg = Path(os.path.expanduser("~/github/freegsnke/machine_configs/MAST-U"))
+tok = build_machine.tokamak(
+    active_coils_path=str(cfg / "MAST-U_like_active_coils.pickle"),
+    passive_coils_path=str(cfg / "MAST-U_like_passive_coils.pickle"),
+    limiter_path=str(cfg / "MAST-U_like_limiter.pickle"),
+    wall_path=str(cfg / "MAST-U_like_wall.pickle"),
+    magnetic_probe_path=str(cfg / "MAST-U_like_magnetic_probes.pickle"),
+)
+eq = equilibrium_update.Equilibrium(tokamak=tok, Rmin=0.1, Rmax=2.0, Zmin=-2.2, Zmax=2.2, nx=65, ny=129)
+profiles = ConstrainPaxisIp(eq=eq, paxis=8e3, Ip=600.0e3, fvac=0.5, alpha_m=1.8, alpha_n=1.2)
+solver = GSstaticsolver.NKGSsolver(eq)
+with open(os.path.expanduser("~/github/freegsnke/examples/data/simple_diverted_currents_PaxisIp.pk"), "rb") as f:
+    currents = pickle.load(f)
+for k, v in currents.items():
+    eq.tokamak[k].current = v * (1.0 + args.perturb)
+solver.solve(eq=eq, profiles=profiles, constrain=None, target_relative_tolerance=1e-9)
+eq._updatePlasmaPsi(eq.plasma_psi * (1.0 + args.perturb_psi))
+tok.probes.initialise_setup(eq)
+timer.mark("freegsnke_forward")
+
+controller = Gsfit(pulseNo=0, run_name="bench", settings_path="mastu_with_synthetic_data_from_freegsnke", write_to_mds=False)
+controller.settings["GSFIT_code_settings.json"]["RAYON_NUM_THREADS"] = args.threads
+if args.perturb_weights != 0.0:
+    for weights_file in ["sensor_weights_bp_probe.json", "sensor_weights_flux_loops.json"]:
+        for sensor_settings in controller.settings[weights_file].values():
+            if isinstance(sensor_settings, dict) and "fit_settings" in sensor_settings:
+                sensor_settings["fit_settings"]["weight"] = sensor_settings["fit_settings"]["weight"] * (1.0 + args.perturb_weights)
+# As in the notebook: sensor data at time = [0.0, 1.0] from two (identical) equilibria;
+# reconstruct at the settings' user_defined [0.5] for one slice, else n_time slices across the window
+time = np.array([0.0, 1.0])
+eqs = [eq, eq]
+kwargs = dict(time=time, freegsnke_eqs=eqs)
+controller.set_environment_variables()
+controller.setup_timeslices()
+if args.n_time != 1:
+    controller.results["TIME"] = np.linspace(0.0, 1.0, args.n_time)
+controller.setup_objects(**kwargs)
+timer.mark("setup_objects")
+controller.calculate_greens()
+timer.mark("calculate_greens")
+controller.inverse_solver_rust()
+timer.mark("inverse_solver")
+controller.write_results_to_mdsplus()
+timer.mark("map_results")
+ip = controller["GLOBAL"]["IP"]
+summary = benchlib.dump_results(controller, out_dir / f"mastu_{args.tag}.npz", {"ip_err_abs_max": float(np.nanmax(np.abs(ip - 600e3)))})
+timer.mark("dump")
+
+if not args.no_isoflux:
+    # Section 2.3 of the notebook: add two isoflux constraints on the mid-plane and re-solve
+    import shapely
+
+    r1 = np.array([0.6, 0.8])
+    mid_r = eq.R_1D
+    mid_psi_n = eq.psiNRZ(mid_r, 0.0 * mid_r)
+    mid_p = eq.pressure(mid_psi_n)
+    r2 = np.full(2, np.nan)
+    for i in range(2):
+        pline = shapely.geometry.LineString(np.column_stack((mid_r, mid_p)))
+        line = shapely.geometry.LineString(np.column_stack(([r1[i], r1[i]], [0.0, 1e8])))
+        p_i = pline.intersection(line).y
+        iso = shapely.geometry.LineString(np.column_stack(([0.0, 10.0], [p_i, p_i])))
+        r2[i] = iso.intersection(pline).geoms[1].x
+    isoflux = gsfit_rs.Isoflux()
+    ttr = controller.results["TIME"]
+    for i in range(2):
+        isoflux.add_sensor(
+            name=f"isoflux_constraint_{i + 1}",
+            fit_settings_comment="",
+            fit_settings_include=True,
+            fit_settings_weight=1.0,
+            time=time,
+            location_1_r=np.full(len(time), r1[i]),
+            location_1_z=np.zeros(len(time)),
+            location_2_r=np.full(len(time), r2[i]),
+            location_2_z=np.zeros(len(time)),
+            times_to_reconstruct=ttr,
+        )
+    controller.isoflux = isoflux
+    controller.calculate_greens()
+    timer.mark("isoflux_greens")
+    controller.inverse_solver_rust()
+    timer.mark("isoflux_solve")
+    controller.write_results_to_mdsplus()
+    summary["isoflux"] = benchlib.dump_results(controller, out_dir / f"mastu_isoflux_{args.tag}.npz")
+    timer.mark("isoflux_map_dump")
+
+payload = {
+    "workload": "mastu_freegsnke_example02",
+    "n_time": args.n_time,
+    "threads": args.threads,
+    "phases_s": timer.as_dict(),
+    "summary": summary,
+    "provenance": benchlib.provenance(repo),
+    "loadavg_end": os.getloadavg(),
+}
+benchlib.write_json(out_dir / f"mastu_{args.tag}.json", payload)
+print("PHASES", {k: round(v, 3) for k, v in payload["phases_s"].items()})
+print("SUMMARY", summary)

--- a/documentation/performance/benchmarks/bench_st40_mock.py
+++ b/documentation/performance/benchmarks/bench_st40_mock.py
@@ -1,0 +1,95 @@
+"""ST40 mock-MDSplus benchmark: real pulse 12050 magnetics (mock trees from tests/),
+default settings (81 x 161 grid, PF coils, 8 passives incl. IVC eigenmodes), N time-slices.
+
+This is the public proxy for GSFit's standard post-shot ST40 workflow.
+Usage: bench_st40_mock.py --n-time 31 --threads 8 --tag baseline --out results/
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import benchlib
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--n-time", type=int, default=31, help="number of time-slices (<= 31 uses distinct mock times; more repeats the window)")
+parser.add_argument("--threads", type=int, default=8)
+parser.add_argument("--n-z", type=int, default=None, help="override grid n_z (default from settings: 161)")
+parser.add_argument("--tag", default="run")
+parser.add_argument("--out", default=str(HERE.parent.parent.parent / "benchmark_results"))
+parser.add_argument("--repo", default=str(HERE.parent.parent.parent))
+args = parser.parse_args()
+
+os.environ["RAYON_NUM_THREADS"] = str(args.threads)
+repo = Path(args.repo)
+out_dir = Path(args.out)
+
+import numpy as np
+
+timer = benchlib.PhaseTimer()
+from gsfit import Gsfit
+
+timer.mark("import")
+
+mock_dir = str(repo / "tests/test_02_delta_z_shift_greater_than_d_z/data")
+# The mock trees hold 31 real samples in a 0.3 ms window around 130 ms (MAG float32, PSU2COIL float64);
+# pick reconstruction times strictly inside the intersection of both time axes so every
+# sensor and coil signal is interpolated rather than extrapolated.
+mag_t = np.load(f"{mock_dir}/mdsplus_mock_mag_12050.npz")["TIME"].astype(np.float64)
+psu_t = np.load(f"{mock_dir}/mdsplus_mock_psu2coil_12050.npz")["TIME"].astype(np.float64)
+t_lo = max(mag_t.min(), psu_t.min()) + 1e-6
+t_hi = min(mag_t.max(), psu_t.max()) - 1e-6
+times = np.array([130e-3]) if args.n_time == 1 else np.linspace(t_lo, t_hi, args.n_time)
+
+controller = Gsfit(pulseNo=12050, run_name="BENCH", run_description="benchmark", settings_path="default", write_to_mds=False)
+cs = controller.settings["GSFIT_code_settings.json"]
+cs["RAYON_NUM_THREADS"] = args.threads
+cs["database_reader"]["method"] = "mock_st40_mdsplus"
+cs["database_reader"]["mock_st40_mdsplus"] = {
+    "mock_dir": mock_dir,
+    "workflow": {
+        "elmag": {"tree_name": "ELMAG", "pulseNo": None, "run_name": "RUN16", "usage": ""},
+        "elmag_coils": {"tree_name": "ELMAG", "pulseNo": 11012050, "run_name": "RUN16", "usage": ""},
+        "mag": {"tree_name": "MAG", "pulseNo": None, "run_name": "BEST", "usage": ""},
+        "psu2coil": {"tree_name": "PSU2COIL", "pulseNo": None, "run_name": "RUN02", "usage": ""},
+        "rog_gaps": {"tree_name": "MAG", "pulseNo": 11010605, "run_name": "RUN14C", "usage": ""},
+    },
+}
+if args.n_z:
+    cs["grid"]["n_z"] = args.n_z
+cs["timeslices"]["method"] = "user_defined"
+cs["timeslices"]["user_defined"] = [float(t) for t in times]
+timer.mark("settings")
+
+# Replicate Gsfit.run() phase by phase so each phase is timed separately
+controller.set_environment_variables()
+controller.setup_timeslices()
+controller.setup_objects()
+timer.mark("setup_objects")
+controller.calculate_greens()
+timer.mark("calculate_greens")
+controller.inverse_solver_rust()
+timer.mark("inverse_solver")
+controller.write_results_to_mdsplus()
+timer.mark("map_results")
+
+summary = benchlib.dump_results(controller, out_dir / f"st40mock_{args.tag}.npz")
+timer.mark("dump")
+payload = {
+    "workload": "st40_mock_12050",
+    "n_time": len(times),
+    "grid": {"n_r": cs["grid"]["n_r"], "n_z": cs["grid"]["n_z"]},
+    "threads": args.threads,
+    "phases_s": timer.as_dict(),
+    "summary": summary,
+    "provenance": benchlib.provenance(repo),
+    "loadavg_end": os.getloadavg(),
+}
+benchlib.write_json(out_dir / f"st40mock_{args.tag}.json", payload)
+print("PHASES", {k: round(v, 3) for k, v in payload["phases_s"].items()})
+print("SUMMARY", summary)

--- a/documentation/performance/benchmarks/benchlib.py
+++ b/documentation/performance/benchmarks/benchlib.py
@@ -1,0 +1,154 @@
+"""Shared helpers for the GSFit offline benchmarks.
+
+Every benchmark records: phase wall-clock times, environment provenance
+(git commit, threads, host), and a compact dump of physically meaningful
+outputs for accuracy comparison between builds.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+
+class PhaseTimer:
+    def __init__(self) -> None:
+        self.phases: list[tuple[str, float]] = []
+        self._t0 = time.perf_counter()
+        self._last = self._t0
+
+    def mark(self, name: str) -> float:
+        now = time.perf_counter()
+        dt = now - self._last
+        self.phases.append((name, dt))
+        self._last = now
+        return dt
+
+    def total(self) -> float:
+        return time.perf_counter() - self._t0
+
+    def as_dict(self) -> dict[str, float]:
+        d = {name: dt for name, dt in self.phases}
+        d["total"] = self.total()
+        return d
+
+
+def git_commit(repo: Path) -> str:
+    try:
+        out = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+        dirty = subprocess.call(["git", "-C", str(repo), "diff", "--quiet"]) != 0
+        return out + ("-dirty" if dirty else "")
+    except Exception as exc:  # pragma: no cover
+        return f"unknown ({exc})"
+
+
+def provenance(repo: Path) -> dict:
+    import gsfit_rs
+
+    return {
+        "git_commit": git_commit(repo),
+        "gsfit_rs_file": getattr(gsfit_rs, "__file__", "?"),
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "RAYON_NUM_THREADS": os.environ.get("RAYON_NUM_THREADS", "(unset)"),
+        "loadavg_start": os.getloadavg(),
+        "argv": sys.argv,
+    }
+
+
+def dump_results(controller, out_npz: Path, extra: dict | None = None) -> dict:
+    """Dump the physically meaningful observables of a finished reconstruction."""
+    plasma = controller.plasma
+    d: dict[str, np.ndarray] = {}
+
+    def grab(obj, keys, getter):
+        try:
+            return getattr(obj, getter)(keys)
+        except BaseException:  # pyo3 PanicException derives from BaseException
+            return None
+
+    d["time"] = plasma.get_array1(["time"])
+    for key in [
+        "ip",
+        "psi_a",
+        "psi_b",
+        "r_mag",
+        "z_mag",
+        "gs_error",
+        "chi_mag",
+        "r_geo",
+        "z_geo",
+        "elongation",
+        "r_minor",
+        "w_mhd",
+        "li_3",
+        "beta_p_1",
+        "q95",
+        "q0",
+        "delta_z",
+        "bounding_r",
+        "bounding_z",
+    ]:
+        v = grab(plasma, ["global", key], "get_array1")
+        if v is not None:
+            d[f"global.{key}"] = np.asarray(v)
+    d["n_iter"] = np.asarray(grab(plasma, ["global", "n_iter"], "get_vec_usize") or [], dtype=np.int64)
+    d["psi_2d"] = plasma.get_array3(["profiles_2d", "r_z", "psi"])
+    d["j_2d"] = plasma.get_array3(["profiles_2d", "r_z", "j"])
+    d["grid_r"] = plasma.get_array1(["grid", "r"])
+    d["grid_z"] = plasma.get_array1(["grid", "z"])
+    d["boundary_r"] = plasma.get_array2(["boundary", "outline", "r"])
+    d["boundary_z"] = plasma.get_array2(["boundary", "outline", "z"])
+    d["boundary_n"] = np.asarray(plasma.get_vec_usize(["boundary", "outline", "n"]), dtype=np.int64)
+    d["p_prime_coefs"] = plasma.get_array2(["source_functions", "p_prime", "coefficients"])
+    d["ff_prime_coefs"] = plasma.get_array2(["source_functions", "ff_prime", "coefficients"])
+    for name in ["p", "q", "f", "ff_prime", "p_prime"]:
+        v = grab(plasma, ["profiles_1d", "psi_norm", name], "get_array2")
+        if v is not None:
+            d[f"profiles_1d.{name}"] = v
+    v = grab(plasma, ["profiles_1d", "r_midplane", "p"], "get_array2")
+    if v is not None:
+        d["profiles_1d.r_midplane.p"] = v
+    for sensors, name in [(controller.bp_probes, "bp_probes"), (controller.flux_loops, "flux_loops"), (controller.rogowski_coils, "rogowski_coils")]:
+        for kind in ["b", "psi", "i"]:
+            m = grab(sensors, ["*", kind, "measured", "value"], "get_array2")
+            c = grab(sensors, ["*", kind, "calculated", "value"], "get_array2")
+            if m is not None and c is not None:
+                d[f"{name}.measured"] = m
+                d[f"{name}.calculated"] = c
+                break
+    # passive currents
+    try:
+        pas = controller.passives
+        for pname in pas.keys():
+            v = grab(pas, [pname, "i"], "get_array1")
+            if v is not None:
+                d[f"passives.{pname}.i"] = np.asarray(v)
+    except Exception:
+        pass
+    out_npz.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(out_npz, **{k: v for k, v in d.items() if v is not None})
+    summary = {
+        "n_time": len(d["time"]),
+        "n_converged": int(np.isfinite(d.get("global.ip", np.array([np.nan]))).sum()),
+        "n_iter_mean": float(np.mean([n for n in d["n_iter"] if n < 10**9])) if len(d["n_iter"]) else None,
+        "ip_mean": float(np.nanmean(d.get("global.ip", np.array([np.nan])))),
+    }
+    if extra:
+        summary.update(extra)
+    return summary
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump(payload, fh, indent=2, default=str)

--- a/documentation/performance/benchmarks/compare_results.py
+++ b/documentation/performance/benchmarks/compare_results.py
@@ -1,0 +1,53 @@
+"""Compare two benchmark result dumps (npz) key by key.
+
+Reports, per key: max |a-b|, max |a-b| / max|a|, and whether they are bitwise identical.
+Exit code 1 if any key exceeds the relative tolerance (default 1e-9) or a key is missing.
+"""
+
+import sys
+
+import numpy as np
+
+a_path, b_path = sys.argv[1], sys.argv[2]
+rtol = float(sys.argv[3]) if len(sys.argv) > 3 else 1e-9
+a = np.load(a_path, allow_pickle=True)
+b = np.load(b_path, allow_pickle=True)
+keys = sorted(set(a.files) | set(b.files))
+worst = 0.0
+bad = []
+print(f"{'key':40s} {'shape':>18s} {'max|a-b|':>12s} {'rel':>10s}  note")
+for k in keys:
+    if k not in a.files or k not in b.files:
+        print(f"{k:40s} MISSING in {'a' if k not in a.files else 'b'}")
+        bad.append(k)
+        continue
+    x, y = np.asarray(a[k]), np.asarray(b[k])
+    if x.shape != y.shape:
+        print(f"{k:40s} shape mismatch {x.shape} vs {y.shape}")
+        bad.append(k)
+        continue
+    if x.dtype.kind not in "fc" or y.dtype.kind not in "fc":
+        same = np.array_equal(x, y)
+        print(f"{k:40s} {x.shape!s:>18s} {'':>12s} {'':>10s}  {'identical' if same else 'DIFFERENT'}")
+        if not same:
+            bad.append(k)
+        continue
+    fx, fy = np.isfinite(x), np.isfinite(y)
+    if not np.array_equal(fx, fy):
+        print(f"{k:40s} {x.shape!s:>18s} finite-pattern differs ({(~fx).sum()} vs {(~fy).sum()} non-finite)")
+        bad.append(k)
+        continue
+    d = np.abs(x[fx] - y[fy])
+    if d.size == 0:
+        print(f"{k:40s} {x.shape!s:>18s} (no finite values)")
+        continue
+    mx = float(np.max(np.abs(x[fx]))) if fx.any() else 0.0
+    md = float(d.max())
+    rel = md / mx if mx > 0 else md
+    note = "bitwise" if md == 0.0 else ("ok" if rel <= rtol else "EXCEEDS")
+    if rel > rtol:
+        bad.append(k)
+    worst = max(worst, rel)
+    print(f"{k:40s} {x.shape!s:>18s} {md:12.3e} {rel:10.2e}  {note}")
+print(f"worst relative difference: {worst:.3e}; tolerance {rtol:.1e}; {'FAIL: ' + ', '.join(bad) if bad else 'PASS'}")
+sys.exit(1 if bad else 0)

--- a/documentation/performance/benchmarks/robustness.py
+++ b/documentation/performance/benchmarks/robustness.py
@@ -1,0 +1,228 @@
+"""Robustness matrix on the public ST40 mock workload.
+
+Runs a set of nominal and degenerate configurations and records, per case, the outcome
+(converged slices, iterations, Ip, error messages printed by the solver, exceptions).
+Run once per build (reference and candidate) and diff the JSON outputs.
+
+Usage: robustness.py --tag ref --repo ../ref
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import benchlib
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--tag", required=True)
+parser.add_argument("--repo", default=str(HERE.parent.parent.parent))
+parser.add_argument("--threads", type=int, default=8)
+parser.add_argument("--out", default=str(HERE.parent.parent.parent / "benchmark_results"))
+args = parser.parse_args()
+os.environ["RAYON_NUM_THREADS"] = str(args.threads)
+repo = Path(args.repo)
+
+import numpy as np
+from gsfit import Gsfit
+
+mock_dir = str(repo / "tests/test_02_delta_z_shift_greater_than_d_z/data")
+WORKFLOW = {
+    "elmag": {"tree_name": "ELMAG", "pulseNo": None, "run_name": "RUN16", "usage": ""},
+    "elmag_coils": {"tree_name": "ELMAG", "pulseNo": 11012050, "run_name": "RUN16", "usage": ""},
+    "mag": {"tree_name": "MAG", "pulseNo": None, "run_name": "BEST", "usage": ""},
+    "psu2coil": {"tree_name": "PSU2COIL", "pulseNo": None, "run_name": "RUN02", "usage": ""},
+    "rog_gaps": {"tree_name": "MAG", "pulseNo": 11010605, "run_name": "RUN14C", "usage": ""},
+}
+
+
+def make_controller(times):
+    c = Gsfit(pulseNo=12050, run_name="ROBUST", run_description="robustness", settings_path="default", write_to_mds=False)
+    cs = c.settings["GSFIT_code_settings.json"]
+    cs["RAYON_NUM_THREADS"] = args.threads
+    cs["database_reader"]["method"] = "mock_st40_mdsplus"
+    cs["database_reader"]["mock_st40_mdsplus"] = {"mock_dir": mock_dir, "workflow": WORKFLOW}
+    cs["timeslices"]["method"] = "user_defined"
+    cs["timeslices"]["user_defined"] = [float(t) for t in times]
+    return c
+
+
+def case_nominal(c):
+    pass
+
+
+def case_zero_initial_current(c):
+    c.settings["GSFIT_code_settings.json"]["initial_guess"]["ip"] = 0.0
+
+
+def case_negative_initial_current(c):
+    c.settings["GSFIT_code_settings.json"]["initial_guess"]["ip"] = -425.0e3
+
+
+def case_initial_ellipse_outside_vessel(c):
+    c.settings["GSFIT_code_settings.json"]["initial_guess"]["r_cur"] = 0.95
+
+
+def case_initial_ellipse_far_off_axis(c):
+    ig = c.settings["GSFIT_code_settings.json"]["initial_guess"]
+    ig["r_cur"] = 0.30
+    ig["z_cur"] = 0.45
+    ig["minor_radius"] = 0.08
+
+
+def case_max_iter_3(c):
+    c.settings["GSFIT_code_settings.json"]["numerics"]["n_iter_max"] = 3
+
+
+def case_tight_tolerance(c):
+    c.settings["GSFIT_code_settings.json"]["numerics"]["gs_error"] = 1.0e-9
+
+
+def case_no_bp_probes(c):
+    for name, v in c.settings["sensor_weights_bp_probe.json"].items():
+        if isinstance(v, dict) and "fit_settings" in v:
+            v["fit_settings"]["include"] = False
+
+
+def case_no_flux_loops(c):
+    for name, v in c.settings["sensor_weights_flux_loops.json"].items():
+        if isinstance(v, dict) and "fit_settings" in v:
+            v["fit_settings"]["include"] = False
+
+
+def case_magnetics_minimal(c):
+    # keep only the first four bp probes and two flux loops (diagnostic degeneracy)
+    kept = 0
+    for name, v in c.settings["sensor_weights_bp_probe.json"].items():
+        if isinstance(v, dict) and "fit_settings" in v:
+            if v["fit_settings"]["include"] and kept < 4:
+                kept += 1
+            else:
+                v["fit_settings"]["include"] = False
+    kept = 0
+    for name, v in c.settings["sensor_weights_flux_loops.json"].items():
+        if isinstance(v, dict) and "fit_settings" in v:
+            if v["fit_settings"]["include"] and kept < 2:
+                kept += 1
+            else:
+                v["fit_settings"]["include"] = False
+
+
+def case_coarse_grid(c):
+    c.settings["GSFIT_code_settings.json"]["grid"]["n_r"] = 61
+    c.settings["GSFIT_code_settings.json"]["grid"]["n_z"] = 121
+
+
+def case_fine_grid_321(c):
+    c.settings["GSFIT_code_settings.json"]["grid"]["n_z"] = 321
+
+
+def case_no_vertical_feedback(c):
+    c.settings["GSFIT_code_settings.json"]["numerics"]["n_iter_no_vertical_feedback"] = 1000
+
+
+def case_higher_order_source_functions(c):
+    c.settings["source_function_p_prime.json"]["efit_polynomial"]["n_dof"] = 4
+    c.settings["source_function_p_prime.json"]["efit_polynomial"]["regularizations"] = [[0.0, 0.0, 0.0, 4.467344e-05]]
+    c.settings["source_function_ff_prime.json"]["efit_polynomial"]["n_dof"] = 3
+    c.settings["source_function_ff_prime.json"]["efit_polynomial"]["regularizations"] = [[0.0, 0.0, 177.734375009]]
+
+
+CASES = {
+    "nominal_3_slices": (case_nominal, [129.9e-3, 130.0e-3, 130.1e-3]),
+    "zero_initial_current": (case_zero_initial_current, [130e-3]),
+    "negative_initial_current": (case_negative_initial_current, [130e-3]),
+    "initial_ellipse_outside_vessel": (case_initial_ellipse_outside_vessel, [130e-3]),
+    "initial_ellipse_far_off_axis": (case_initial_ellipse_far_off_axis, [130e-3]),
+    "max_iter_3": (case_max_iter_3, [130e-3]),
+    "tight_tolerance_1e-9": (case_tight_tolerance, [130e-3]),
+    "no_bp_probes": (case_no_bp_probes, [130e-3]),
+    "no_flux_loops": (case_no_flux_loops, [130e-3]),
+    "magnetics_minimal_4bp_2fl": (case_magnetics_minimal, [130e-3]),
+    "coarse_grid_61x121": (case_coarse_grid, [130e-3]),
+    "fine_grid_81x321": (case_fine_grid_321, [130e-3]),
+    "no_vertical_feedback": (case_no_vertical_feedback, [130e-3]),
+    "higher_order_source_functions": (case_higher_order_source_functions, [130e-3]),
+}
+
+results = {}
+for name, (fn, times) in CASES.items():
+    record = {"times": times}
+    # Capture at the file-descriptor level so the Rust solver's println! messages are recorded as well
+    capture = tempfile.TemporaryFile(mode="w+")
+    saved_stdout = os.dup(1)
+    saved_stderr = os.dup(2)
+    sys.stdout.flush()
+    os.dup2(capture.fileno(), 1)
+    os.dup2(capture.fileno(), 2)
+    try:
+        c = make_controller(times)
+        fn(c)
+        c.run()
+        plasma = c.plasma
+        ip = np.asarray(plasma.get_array1(["global", "ip"]))
+        n_iter = [int(n) for n in plasma.get_vec_usize(["global", "n_iter"])]
+        gs_err = np.asarray(plasma.get_array1(["global", "gs_error"]))
+        chi = np.asarray(plasma.get_array1(["global", "chi_mag"]))
+        record.update(
+            {
+                "outcome": "ran",
+                "n_converged": int(np.isfinite(ip).sum()),
+                "n_time": len(ip),
+                "ip": [float(x) for x in ip],
+                "n_iter": n_iter,
+                "gs_error": [float(x) for x in gs_err],
+                "chi_mag": [float(x) for x in chi],
+                "r_mag": [float(x) for x in plasma.get_array1(["global", "r_mag"])],
+                "z_mag": [float(x) for x in plasma.get_array1(["global", "z_mag"])],
+                "psi_a": [float(x) for x in plasma.get_array1(["global", "psi_a"])],
+                "psi_b": [float(x) for x in plasma.get_array1(["global", "psi_b"])],
+            }
+        )
+    except BaseException as exc:  # pyo3 PanicException derives from BaseException
+        record.update({"outcome": "exception", "exception": f"{type(exc).__name__}: {str(exc)[:300]}"})
+    finally:
+        sys.stdout.flush()
+        os.dup2(saved_stdout, 1)
+        os.dup2(saved_stderr, 2)
+        os.close(saved_stdout)
+        os.close(saved_stderr)
+    capture.seek(0)
+    out = capture.read()
+    capture.close()
+    record["solver_messages"] = sorted(
+        set(
+            l.strip()
+            for l in out.splitlines()
+            if any(
+                k in l
+                for k in [
+                    "Error",
+                    "error_state",
+                    "NoBoundary",
+                    "NoMagnetic",
+                    "NoStationary",
+                    "MaxIter",
+                    "Invalid",
+                    "Warning",
+                    "rank-deficient",
+                    "norm of column",
+                ]
+            )
+        )
+    )[:12]
+    record["solution_lines"] = [l.strip() for l in out.splitlines() if "solution_found" in l][:5]
+    results[name] = record
+    print(
+        f"{name:34s} {record.get('outcome')}  converged={record.get('n_converged')}/{record.get('n_time')}  n_iter={record.get('n_iter')}  msgs={record['solver_messages'][:2]}",
+        flush=True,
+    )
+
+out_path = Path(args.out) / f"robustness_{args.tag}.json"
+benchlib.write_json(out_path, {"provenance": benchlib.provenance(repo), "cases": results})
+print("wrote", out_path)

--- a/documentation/performance/benchmarks/run_notebook.py
+++ b/documentation/performance/benchmarks/run_notebook.py
@@ -1,0 +1,62 @@
+"""Execute a GSFit example notebook's code cells headlessly and dump the reconstruction results.
+
+Usage: run_notebook.py examples/example_07__....ipynb --tag baseline [--threads 8] [--out results/]
+The notebook is executed as one script (IPython magics stripped, matplotlib Agg backend), the total
+wall-clock is recorded, and `gsfit_controller` results are dumped with benchlib.dump_results.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import benchlib
+
+parser = argparse.ArgumentParser()
+parser.add_argument("notebook")
+parser.add_argument("--tag", required=True)
+parser.add_argument("--threads", type=int, default=8)
+parser.add_argument("--out", default=str(HERE.parent.parent.parent / "benchmark_results"))
+parser.add_argument("--repo", default=None)
+args = parser.parse_args()
+os.environ["RAYON_NUM_THREADS"] = str(args.threads)
+os.environ["MPLBACKEND"] = "Agg"
+nb_path = Path(args.notebook).resolve()
+repo = Path(args.repo) if args.repo else nb_path.parent.parent
+out_dir = Path(args.out)
+os.chdir(nb_path.parent)
+
+with open(nb_path) as fh:
+    nb = json.load(fh)
+lines: list[str] = []
+for cell in nb["cells"]:
+    if cell["cell_type"] != "code":
+        continue
+    for line in "".join(cell["source"]).splitlines():
+        if line.lstrip().startswith(("%", "!")):
+            continue
+        lines.append(line)
+source = "\n".join(lines)
+
+namespace: dict = {"__name__": "__main__"}
+t0 = time.perf_counter()
+exec(compile(source, str(nb_path), "exec"), namespace)
+wall = time.perf_counter() - t0
+controller = namespace.get("gsfit_controller")
+summary = benchlib.dump_results(controller, out_dir / f"{nb_path.stem}_{args.tag}.npz") if controller is not None else {}
+payload = {
+    "workload": nb_path.name,
+    "threads": args.threads,
+    "wall_s": wall,
+    "summary": summary,
+    "provenance": benchlib.provenance(repo),
+    "loadavg_end": os.getloadavg(),
+}
+benchlib.write_json(out_dir / f"{nb_path.stem}_{args.tag}.json", payload)
+print("NOTEBOOK", nb_path.name, "wall_s", round(wall, 2), "SUMMARY", summary)

--- a/rust/gsfit_rs/Cargo.toml
+++ b/rust/gsfit_rs/Cargo.toml
@@ -31,6 +31,7 @@ approx = "0.5.1"
 faer = "0.24.4"
 ndarray-stats = "0.7.0"  # TODO: I want to remove this dependency, because it restricts `ndarray` version!
 rand = "0.10.2"
+realfft = "3.5.0"  # Real-to-complex FFTs for the plasma Green's convolution along z
 special = "0.14.0" # "special" mathematical functions, used for `Lambert`
 
 [build-dependencies]

--- a/rust/gsfit_rs/src/grad_shafranov/grad_shafranov_solver.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/grad_shafranov_solver.rs
@@ -1,8 +1,10 @@
 use super::epp_chi_sq_mag::epp_chi_sq_mag;
 use super::gs_solution::GsSolution;
+use super::gs_solution::PsiAndDerivativesGreens;
 use crate::coils::Coils;
 use crate::passives::Passives;
 use crate::plasma::Plasma;
+use crate::plasma_geometry::vessel_mask;
 use crate::sensors::{BpProbes, Dialoop, FluxLoops, Isoflux, IsofluxBoundary, Pressure, RogowskiCoils, SensorsDynamic, SensorsStatic, StationaryPoint};
 use crate::source_functions::SourceFunctionTraits;
 use log::info; // use log::{debug, error, info};
@@ -73,11 +75,9 @@ pub fn solve_grad_shafranov(
     // TF rod current interpolated to `times_to_reconstruct`; used as f_vac = MU_0 * i_rod / (2 * PI)
     // in the diamagnetic-loop constraint
     let i_rod_vs_time: Array1<f64> = coils.results.get("tf").get("rod_i").get("measured").get("value").unwrap_array1();
-    let (bp_probes_static, bp_probes_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
-        bp_probes.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
-    let (flux_loops_static, flux_loops_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
-        flux_loops.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
-    let (rogowski_coils_static, rogowski_coils_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
+    let (bp_probes_static, bp_probes_dynamic): (SensorsStatic, Vec<SensorsDynamic>) = bp_probes.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
+    let (flux_loops_static, flux_loops_dynamic): (SensorsStatic, Vec<SensorsDynamic>) = flux_loops.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
+    let (rogowski_coils_static, rogowski_coils_dynamic): (SensorsStatic, Vec<SensorsDynamic>) =
         rogowski_coils.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
     let (isoflux_statics, isoflux_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) = isoflux.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
     let (isoflux_boundary_statics, isoflux_boundary_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
@@ -86,7 +86,7 @@ pub fn solve_grad_shafranov(
         pressure_sensors.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
     let (stationary_point_statics, stationary_point_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) =
         stationary_point.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
-    let (dialoop_statics, dialoop_dynamic): (Vec<SensorsStatic>, Vec<SensorsDynamic>) = dialoop.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
+    let (dialoop_static, dialoop_dynamic): (SensorsStatic, Vec<SensorsDynamic>) = dialoop.split_into_static_and_dynamic(&times_to_reconstruct_ndarray);
 
     // TODO: might be better to combine all sensors here, before passing to the solver
 
@@ -144,6 +144,15 @@ pub fn solve_grad_shafranov(
         i_reg += n_passive_regularisation_this_passive;
     }
 
+    // Quantities shared by every time-slice (and every Picard iteration), calculated once:
+    // the reorganised plasma/coil/passive Green's tables and the inside-vessel grid mask
+    let psi_and_derivatives_greens: PsiAndDerivativesGreens = PsiAndDerivativesGreens::new(&plasma_owned);
+    let grid_r: Array1<f64> = plasma_owned.results.get("grid").get("r").unwrap_array1();
+    let grid_z: Array1<f64> = plasma_owned.results.get("grid").get("z").unwrap_array1();
+    let vessel_r: Array1<f64> = plasma_owned.results.get("vessel").get("r").unwrap_array1();
+    let vessel_z: Array1<f64> = plasma_owned.results.get("vessel").get("z").unwrap_array1();
+    let mask_vessel_2d: Array2<bool> = vessel_mask(&grid_r, &grid_z, &vessel_r, &vessel_z);
+
     // loop over time in parallel and store in "results"
     let timing_start: Instant = Instant::now();
     let mut gs_solutions: Vec<GsSolution> = (0..n_time)
@@ -155,13 +164,13 @@ pub fn solve_grad_shafranov(
             let mut gs_object: GsSolution = GsSolution::new(
                 &plasma_owned,
                 &coils_dynamic[i_time],
-                &bp_probes_static[i_time],
+                &bp_probes_static,
                 &bp_probes_dynamic[i_time],
-                &flux_loops_static[i_time],
+                &flux_loops_static,
                 &flux_loops_dynamic[i_time],
-                &dialoop_statics[i_time],
+                &dialoop_static,
                 &dialoop_dynamic[i_time],
-                &rogowski_coils_static[i_time],
+                &rogowski_coils_static,
                 &rogowski_coils_dynamic[i_time],
                 &isoflux_statics[i_time],
                 &isoflux_dynamic[i_time],
@@ -180,6 +189,8 @@ pub fn solve_grad_shafranov(
                 ff_prime_source_function.clone(),
                 passive_regularisations.clone(),
                 passive_regularisations_weight.clone(),
+                &psi_and_derivatives_greens,
+                &mask_vessel_2d,
             );
 
             // Solve

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -13,7 +13,6 @@ use crate::sensors::{SensorsDynamic, SensorsStatic};
 use crate::source_functions::SourceFunctionTraits;
 use faer::linalg::solvers::{SolveLstsq, Svd as FaerSvd};
 use geo::{Contains, Coord, LineString, Point, Polygon};
-use ndarray::Axis;
 use ndarray::{Array1, Array2, Array3, ArrayView2, s};
 use ndarray_stats::QuantileExt;
 use std::f64::consts::PI;

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -408,6 +408,16 @@ pub struct GsSolution<'a> {
     pub ff_prime_dof_values: Array1<f64>,
     pub p_prime_dof_values: Array1<f64>,
     pub psi_2d_coils: Array2<f64>,
+    /// Derivatives of the PF coil flux on the grid; fixed within a time-slice, filled on the first
+    /// call of `calculate_psi_and_derivatives` (empty until then)
+    d_psi_d_r_2d_coils: Array2<f64>,
+    d_psi_d_z_2d_coils: Array2<f64>,
+    d2_psi_d_r2_2d_coils: Array2<f64>,
+    d2_psi_d_r_d_z_2d_coils: Array2<f64>,
+    d2_psi_d_z2_2d_coils: Array2<f64>,
+    d3_psi_d_r2_d_z_2d_coils: Array2<f64>,
+    d3_psi_d_r_d_z2_2d_coils: Array2<f64>,
+    d3_psi_d_z3_2d_coils: Array2<f64>,
     pub passive_dof_values: Array1<f64>,
     pub psi_2d: Array2<f64>,
     pub d_psi_d_r_2d: Array2<f64>,
@@ -516,6 +526,14 @@ impl<'a> GsSolution<'a> {
             j_2d: Array2::zeros((0, 0)),
             mask: Array2::zeros((0, 0)),
             psi_2d_coils: Array2::zeros((0, 0)),
+            d_psi_d_r_2d_coils: Array2::zeros((0, 0)),
+            d_psi_d_z_2d_coils: Array2::zeros((0, 0)),
+            d2_psi_d_r2_2d_coils: Array2::zeros((0, 0)),
+            d2_psi_d_r_d_z_2d_coils: Array2::zeros((0, 0)),
+            d2_psi_d_z2_2d_coils: Array2::zeros((0, 0)),
+            d3_psi_d_r2_d_z_2d_coils: Array2::zeros((0, 0)),
+            d3_psi_d_r_d_z2_2d_coils: Array2::zeros((0, 0)),
+            d3_psi_d_z3_2d_coils: Array2::zeros((0, 0)),
             psi_b: f64::NAN,
             psi_a: f64::NAN,
             ip: f64::NAN,
@@ -861,6 +879,17 @@ impl<'a> GsSolution<'a> {
             let psi_n_flat: Array1<f64> = Array1::from_iter(psi_n_2d.iter().cloned());
             let j_2d_flat: Array1<f64> = Array1::from_iter(j_2d.iter().cloned());
 
+            // Source-function basis functions on the grid, evaluated once per iteration
+            // (they were re-evaluated for every sensor and degree of freedom in the fitting matrix)
+            let mut p_prime_basis: Vec<Array1<f64>> = Vec::with_capacity(n_p_prime_dof);
+            for i_p_prime_dof in 0..n_p_prime_dof {
+                p_prime_basis.push(p_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_p_prime_dof));
+            }
+            let mut ff_prime_basis: Vec<Array1<f64>> = Vec::with_capacity(n_ff_prime_dof);
+            for i_ff_prime_dof in 0..n_ff_prime_dof {
+                ff_prime_basis.push(ff_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_ff_prime_dof));
+            }
+
             let n_vertical_stabilisation: usize;
             if i_iter > n_iter_no_vertical_feedback {
                 n_vertical_stabilisation = 1;
@@ -884,14 +913,8 @@ impl<'a> GsSolution<'a> {
 
                 // p_prime degrees of freedom
                 for i_p_prime_dof in 0..n_p_prime_dof {
-                    fitting_matrix[(i_constraint, i_p_prime_dof)] = 2.0
-                        * PI
-                        * d_area
-                        * (&greens_bp_probes_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * p_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_p_prime_dof)
-                            * &flat_r)
-                            .sum();
+                    fitting_matrix[(i_constraint, i_p_prime_dof)] =
+                        2.0 * PI * d_area * (&greens_bp_probes_grid.slice(s![.., i_sensor]) * &mask_flat * &p_prime_basis[i_p_prime_dof] * &flat_r).sum();
                 }
 
                 // ff_prime degrees of freedom
@@ -899,11 +922,7 @@ impl<'a> GsSolution<'a> {
                     fitting_matrix[(i_constraint, n_p_prime_dof + i_ff_prime_dof)] = 2.0
                         * PI
                         * d_area
-                        * (&greens_bp_probes_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * ff_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_ff_prime_dof)
-                            / (MU_0 * &flat_r))
-                            .sum();
+                        * (&greens_bp_probes_grid.slice(s![.., i_sensor]) * &mask_flat * &ff_prime_basis[i_ff_prime_dof] / (MU_0 * &flat_r)).sum();
                 }
 
                 // Add passive degrees of freedom
@@ -936,14 +955,8 @@ impl<'a> GsSolution<'a> {
             for i_sensor in 0..n_fl {
                 // p_prime degrees of freedom
                 for i_p_prime_dof in 0..n_p_prime_dof {
-                    fitting_matrix[(i_constraint, i_p_prime_dof)] = 2.0
-                        * PI
-                        * d_area
-                        * (&greens_flux_loops_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * p_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_p_prime_dof)
-                            * &flat_r)
-                            .sum();
+                    fitting_matrix[(i_constraint, i_p_prime_dof)] =
+                        2.0 * PI * d_area * (&greens_flux_loops_grid.slice(s![.., i_sensor]) * &mask_flat * &p_prime_basis[i_p_prime_dof] * &flat_r).sum();
                 }
 
                 // ff_prime degrees of freedom
@@ -951,11 +964,7 @@ impl<'a> GsSolution<'a> {
                     fitting_matrix[(i_constraint, n_p_prime_dof + i_ff_prime_dof)] = 2.0
                         * PI
                         * d_area
-                        * (&greens_flux_loops_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * ff_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_ff_prime_dof)
-                            / (MU_0 * &flat_r))
-                            .sum();
+                        * (&greens_flux_loops_grid.slice(s![.., i_sensor]) * &mask_flat * &ff_prime_basis[i_ff_prime_dof] / (MU_0 * &flat_r)).sum();
                 }
 
                 // Add passive degrees of freedom
@@ -1033,14 +1042,8 @@ impl<'a> GsSolution<'a> {
             for i_sensor in 0..n_rog {
                 // p_prime degrees of freedom
                 for i_p_prime_dof in 0..n_p_prime_dof {
-                    fitting_matrix[(i_constraint, i_p_prime_dof)] = 2.0
-                        * PI
-                        * d_area
-                        * (&greens_rogowski_coils_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * p_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_p_prime_dof)
-                            * &flat_r)
-                            .sum();
+                    fitting_matrix[(i_constraint, i_p_prime_dof)] =
+                        2.0 * PI * d_area * (&greens_rogowski_coils_grid.slice(s![.., i_sensor]) * &mask_flat * &p_prime_basis[i_p_prime_dof] * &flat_r).sum();
                 }
 
                 // ff_prime degrees of freedom
@@ -1048,11 +1051,7 @@ impl<'a> GsSolution<'a> {
                     fitting_matrix[(i_constraint, n_p_prime_dof + i_ff_prime_dof)] = 2.0
                         * PI
                         * d_area
-                        * (&greens_rogowski_coils_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * ff_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_ff_prime_dof)
-                            / (MU_0 * &flat_r))
-                            .sum();
+                        * (&greens_rogowski_coils_grid.slice(s![.., i_sensor]) * &mask_flat * &ff_prime_basis[i_ff_prime_dof] / (MU_0 * &flat_r)).sum();
                 }
 
                 // Add passive degrees of freedom
@@ -1085,14 +1084,8 @@ impl<'a> GsSolution<'a> {
             for i_sensor in 0..n_isoflux {
                 // p_prime degrees of freedom
                 for i_p_prime_dof in 0..n_p_prime_dof {
-                    fitting_matrix[(i_constraint, i_p_prime_dof)] = 2.0
-                        * PI
-                        * d_area
-                        * (&greens_isoflux_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * p_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_p_prime_dof)
-                            * &flat_r)
-                            .sum();
+                    fitting_matrix[(i_constraint, i_p_prime_dof)] =
+                        2.0 * PI * d_area * (&greens_isoflux_grid.slice(s![.., i_sensor]) * &mask_flat * &p_prime_basis[i_p_prime_dof] * &flat_r).sum();
                 }
 
                 // ff_prime degrees of freedom
@@ -1100,11 +1093,7 @@ impl<'a> GsSolution<'a> {
                     fitting_matrix[(i_constraint, n_p_prime_dof + i_ff_prime_dof)] = 2.0
                         * PI
                         * d_area
-                        * (&greens_isoflux_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * ff_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_ff_prime_dof)
-                            / (MU_0 * &flat_r))
-                            .sum();
+                        * (&greens_isoflux_grid.slice(s![.., i_sensor]) * &mask_flat * &ff_prime_basis[i_ff_prime_dof] / (MU_0 * &flat_r)).sum();
                 }
 
                 // Add passive degrees of freedom
@@ -1140,11 +1129,7 @@ impl<'a> GsSolution<'a> {
                     fitting_matrix[(i_constraint, i_p_prime_dof)] = 2.0
                         * PI
                         * d_area
-                        * (&greens_isoflux_boundary_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * p_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_p_prime_dof)
-                            * &flat_r)
-                            .sum();
+                        * (&greens_isoflux_boundary_grid.slice(s![.., i_sensor]) * &mask_flat * &p_prime_basis[i_p_prime_dof] * &flat_r).sum();
                 }
 
                 // ff_prime degrees of freedom
@@ -1152,11 +1137,7 @@ impl<'a> GsSolution<'a> {
                     fitting_matrix[(i_constraint, n_p_prime_dof + i_ff_prime_dof)] = 2.0
                         * PI
                         * d_area
-                        * (&greens_isoflux_boundary_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * ff_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_ff_prime_dof)
-                            / (MU_0 * &flat_r))
-                            .sum();
+                        * (&greens_isoflux_boundary_grid.slice(s![.., i_sensor]) * &mask_flat * &ff_prime_basis[i_ff_prime_dof] / (MU_0 * &flat_r)).sum();
                 }
 
                 // Add passive degrees of freedom
@@ -1278,14 +1259,8 @@ impl<'a> GsSolution<'a> {
             for i_sensor in 0..n_magnetic_axis_constraints {
                 // p_prime degrees of freedom
                 for i_p_prime_dof in 0..n_p_prime_dof {
-                    fitting_matrix[(i_constraint, i_p_prime_dof)] = 2.0
-                        * PI
-                        * d_area
-                        * (&greens_magnetic_axis_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * p_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_p_prime_dof)
-                            * &flat_r)
-                            .sum();
+                    fitting_matrix[(i_constraint, i_p_prime_dof)] =
+                        2.0 * PI * d_area * (&greens_magnetic_axis_grid.slice(s![.., i_sensor]) * &mask_flat * &p_prime_basis[i_p_prime_dof] * &flat_r).sum();
                 }
 
                 // ff_prime degrees of freedom
@@ -1293,11 +1268,7 @@ impl<'a> GsSolution<'a> {
                     fitting_matrix[(i_constraint, n_p_prime_dof + i_ff_prime_dof)] = 2.0
                         * PI
                         * d_area
-                        * (&greens_magnetic_axis_grid.slice(s![.., i_sensor])
-                            * &mask_flat
-                            * ff_prime_source_function.source_function_value_single_dof(&psi_n_flat, i_ff_prime_dof)
-                            / (MU_0 * &flat_r))
-                            .sum();
+                        * (&greens_magnetic_axis_grid.slice(s![.., i_sensor]) * &mask_flat * &ff_prime_basis[i_ff_prime_dof] / (MU_0 * &flat_r)).sum();
                 }
 
                 // Add passive degrees of freedom
@@ -1523,9 +1494,11 @@ impl<'a> GsSolution<'a> {
         let n_r: usize = plasma.results.get("grid").get("n_r").unwrap_usize();
         let n_z: usize = plasma.results.get("grid").get("n_z").unwrap_usize();
         let d_area: f64 = plasma.results.get("grid").get("d_area").unwrap_f64();
-        let j_2d: &Array2<f64> = &self.j_2d;
-        let pf_coil_currents: &Array1<f64> = &self.coils_dynamic.measured;
-        let passive_dof_values: &Array1<f64> = &self.passive_dof_values;
+        let j_2d: Array2<f64> = self.j_2d.clone();
+        let coils_dynamic: &SensorsDynamic = self.coils_dynamic;
+        let pf_coil_currents: &Array1<f64> = &coils_dynamic.measured;
+        let passive_dof_values: Array1<f64> = self.passive_dof_values.clone();
+        let passive_dof_values: &Array1<f64> = &passive_dof_values;
         let delta_z: f64 = self.delta_z;
 
         // ====================================================================
@@ -1542,17 +1515,28 @@ impl<'a> GsSolution<'a> {
         };
 
         // PF coils
-        // `psi` is precomputed (the PF currents are fixed within a time-slice);
-        // the other fields are the Greens tables contracted with the PF currents
+        // `psi` is precomputed (the PF currents are fixed within a time-slice); the other fields are
+        // the Greens tables contracted with the PF currents, calculated on the first iteration and
+        // reused by the following ones
+        if self.d_psi_d_r_2d_coils.is_empty() {
+            self.d_psi_d_r_2d_coils = contract(&greens_tables.g_d_psi_d_r_coils_matrix, pf_coil_currents);
+            self.d_psi_d_z_2d_coils = contract(&greens_tables.g_d_psi_d_z_coils_matrix, pf_coil_currents);
+            self.d2_psi_d_r2_2d_coils = contract(&greens_tables.g_d2_psi_d_r2_coils_matrix, pf_coil_currents);
+            self.d2_psi_d_r_d_z_2d_coils = contract(&greens_tables.g_d2_psi_d_r_d_z_coils_matrix, pf_coil_currents);
+            self.d2_psi_d_z2_2d_coils = contract(&greens_tables.g_d2_psi_d_z2_coils_matrix, pf_coil_currents);
+            self.d3_psi_d_r2_d_z_2d_coils = contract(&greens_tables.g_d3_psi_d_r2_d_z_coils_matrix, pf_coil_currents);
+            self.d3_psi_d_r_d_z2_2d_coils = contract(&greens_tables.g_d3_psi_d_r_d_z2_coils_matrix, pf_coil_currents);
+            self.d3_psi_d_z3_2d_coils = contract(&greens_tables.g_d3_psi_d_z3_coils_matrix, pf_coil_currents);
+        }
         let psi_2d_coils: &Array2<f64> = &self.psi_2d_coils;
-        let d_psi_d_r_2d_coils: Array2<f64> = contract(&greens_tables.g_d_psi_d_r_coils_matrix, pf_coil_currents);
-        let d_psi_d_z_2d_coils: Array2<f64> = contract(&greens_tables.g_d_psi_d_z_coils_matrix, pf_coil_currents);
-        let d2_psi_d_r2_2d_coils: Array2<f64> = contract(&greens_tables.g_d2_psi_d_r2_coils_matrix, pf_coil_currents);
-        let d2_psi_d_r_d_z_2d_coils: Array2<f64> = contract(&greens_tables.g_d2_psi_d_r_d_z_coils_matrix, pf_coil_currents);
-        let d2_psi_d_z2_2d_coils: Array2<f64> = contract(&greens_tables.g_d2_psi_d_z2_coils_matrix, pf_coil_currents);
-        let d3_psi_d_r2_d_z_2d_coils: Array2<f64> = contract(&greens_tables.g_d3_psi_d_r2_d_z_coils_matrix, pf_coil_currents);
-        let d3_psi_d_r_d_z2_2d_coils: Array2<f64> = contract(&greens_tables.g_d3_psi_d_r_d_z2_coils_matrix, pf_coil_currents);
-        let d3_psi_d_z3_2d_coils: Array2<f64> = contract(&greens_tables.g_d3_psi_d_z3_coils_matrix, pf_coil_currents);
+        let d_psi_d_r_2d_coils: &Array2<f64> = &self.d_psi_d_r_2d_coils;
+        let d_psi_d_z_2d_coils: &Array2<f64> = &self.d_psi_d_z_2d_coils;
+        let d2_psi_d_r2_2d_coils: &Array2<f64> = &self.d2_psi_d_r2_2d_coils;
+        let d2_psi_d_r_d_z_2d_coils: &Array2<f64> = &self.d2_psi_d_r_d_z_2d_coils;
+        let d2_psi_d_z2_2d_coils: &Array2<f64> = &self.d2_psi_d_z2_2d_coils;
+        let d3_psi_d_r2_d_z_2d_coils: &Array2<f64> = &self.d3_psi_d_r2_d_z_2d_coils;
+        let d3_psi_d_r_d_z2_2d_coils: &Array2<f64> = &self.d3_psi_d_r_d_z2_2d_coils;
+        let d3_psi_d_z3_2d_coils: &Array2<f64> = &self.d3_psi_d_z3_2d_coils;
 
         // Passives: the Greens tables contracted with the passive degrees of freedom
         let psi_2d_passives: Array2<f64> = contract(&greens_tables.g_psi_passives_matrix, passive_dof_values);
@@ -1567,7 +1551,7 @@ impl<'a> GsSolution<'a> {
 
         // Plasma: FFT convolution along `z` (see `PlasmaGreensSpectra`); the even and odd kernels are
         // returned as column-wise concatenated blocks, shape = (n_z, 5 * n_r) and (n_z, 4 * n_r)
-        let (plasma_even, plasma_odd): (Array2<f64>, Array2<f64>) = greens_tables.plasma_spectra.convolve(j_2d, d_area);
+        let (plasma_even, plasma_odd): (Array2<f64>, Array2<f64>) = greens_tables.plasma_spectra.convolve(&j_2d, d_area);
 
         // Assemble the unshifted fields (coils + passives + plasma).
         // The `plasma_even` / `plasma_odd` column blocks follow the kernel order documented on `PlasmaGreensSpectra`

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -506,6 +506,10 @@ pub struct GsSolution<'a> {
     pub ff_prime_source_function: Arc<dyn SourceFunctionTraits + Send + Sync>,
     passive_regularisations: Array2<f64>,
     passive_regularisations_weight: Array1<f64>,
+    /// Reorganised Green's tables, shared by all time-slices (see `PsiAndDerivativesGreens`)
+    psi_and_derivatives_greens: &'a PsiAndDerivativesGreens,
+    /// `true` for grid points inside the vacuum vessel, shared by all time-slices
+    mask_vessel_2d: &'a Array2<bool>,
     pub error_state: Option<Error>,
 }
 
@@ -538,6 +542,8 @@ impl<'a> GsSolution<'a> {
         ff_prime_source_function: Arc<dyn SourceFunctionTraits + Send + Sync>,
         passive_regularisations: Array2<f64>,
         passive_regularisations_weight: Array1<f64>,
+        psi_and_derivatives_greens: &'a PsiAndDerivativesGreens,
+        mask_vessel_2d: &'a Array2<bool>,
     ) -> Self {
         GsSolution {
             // Object inputs
@@ -598,6 +604,8 @@ impl<'a> GsSolution<'a> {
             ff_prime_source_function,
             passive_regularisations,
             passive_regularisations_weight,
+            psi_and_derivatives_greens,
+            mask_vessel_2d,
             error_state: None,
         }
     }
@@ -707,35 +715,35 @@ impl<'a> GsSolution<'a> {
             + n_delta_z_regularisation;
 
         // Magnetic sensor's Greens tables
-        let greens_bp_probes_grid: Array2<f64> = bp_probes_static.greens_with_grid.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_d_bp_probes_dz: Array2<f64> = bp_probes_static.greens_d_sensor_dz.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_bp_probes_pf: Array2<f64> = bp_probes_static.greens_with_pf.to_owned(); // shape = [n_pf, n_sensors]
-        let greens_bp_probes_passives: Array2<f64> = bp_probes_static.greens_with_passives.to_owned(); // shape = [n_passive_dof, n_sensors]
+        let greens_bp_probes_grid: &Array2<f64> = &bp_probes_static.greens_with_grid; // shape = [n_z*n_r, n_sensors]
+        let greens_d_bp_probes_dz: &Array2<f64> = &bp_probes_static.greens_d_sensor_dz; // shape = [n_z*n_r, n_sensors]
+        let greens_bp_probes_pf: &Array2<f64> = &bp_probes_static.greens_with_pf; // shape = [n_pf, n_sensors]
+        let greens_bp_probes_passives: &Array2<f64> = &bp_probes_static.greens_with_passives; // shape = [n_passive_dof, n_sensors]
 
-        let greens_flux_loops_grid: Array2<f64> = flux_loops_static.greens_with_grid.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_d_flux_loops_dz: Array2<f64> = flux_loops_static.greens_d_sensor_dz.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_flux_loops_pf: Array2<f64> = flux_loops_static.greens_with_pf.to_owned(); // shape = [n_pf, n_sensors]
-        let greens_flux_loops_passives: Array2<f64> = flux_loops_static.greens_with_passives.to_owned(); // shape = [n_passive_dof, n_sensors]
+        let greens_flux_loops_grid: &Array2<f64> = &flux_loops_static.greens_with_grid; // shape = [n_z*n_r, n_sensors]
+        let greens_d_flux_loops_dz: &Array2<f64> = &flux_loops_static.greens_d_sensor_dz; // shape = [n_z*n_r, n_sensors]
+        let greens_flux_loops_pf: &Array2<f64> = &flux_loops_static.greens_with_pf; // shape = [n_pf, n_sensors]
+        let greens_flux_loops_passives: &Array2<f64> = &flux_loops_static.greens_with_passives; // shape = [n_passive_dof, n_sensors]
 
-        let greens_rogowski_coils_grid: Array2<f64> = rogowski_coils_static.greens_with_grid.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_d_rogowski_coils_dz: Array2<f64> = rogowski_coils_static.greens_d_sensor_dz.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_rogowski_coils_pf: Array2<f64> = rogowski_coils_static.greens_with_pf.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_rogowski_coils_passives: Array2<f64> = rogowski_coils_static.greens_with_passives.to_owned(); // shape = [n_passive_dof, n_sensors]
+        let greens_rogowski_coils_grid: &Array2<f64> = &rogowski_coils_static.greens_with_grid; // shape = [n_z*n_r, n_sensors]
+        let greens_d_rogowski_coils_dz: &Array2<f64> = &rogowski_coils_static.greens_d_sensor_dz; // shape = [n_z*n_r, n_sensors]
+        let greens_rogowski_coils_pf: &Array2<f64> = &rogowski_coils_static.greens_with_pf; // shape = [n_z*n_r, n_sensors]
+        let greens_rogowski_coils_passives: &Array2<f64> = &rogowski_coils_static.greens_with_passives; // shape = [n_passive_dof, n_sensors]
 
-        let greens_isoflux_grid: Array2<f64> = isoflux_static.greens_with_grid.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_d_isoflux_dz: Array2<f64> = isoflux_static.greens_d_sensor_dz.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_isoflux_pf: Array2<f64> = isoflux_static.greens_with_pf.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_isoflux_passives: Array2<f64> = isoflux_static.greens_with_passives.to_owned(); // shape = [n_passive_dof, n_sensors]
+        let greens_isoflux_grid: &Array2<f64> = &isoflux_static.greens_with_grid; // shape = [n_z*n_r, n_sensors]
+        let greens_d_isoflux_dz: &Array2<f64> = &isoflux_static.greens_d_sensor_dz; // shape = [n_z*n_r, n_sensors]
+        let greens_isoflux_pf: &Array2<f64> = &isoflux_static.greens_with_pf; // shape = [n_z*n_r, n_sensors]
+        let greens_isoflux_passives: &Array2<f64> = &isoflux_static.greens_with_passives; // shape = [n_passive_dof, n_sensors]
 
-        let greens_isoflux_boundary_grid: Array2<f64> = isoflux_boundary_static.greens_with_grid.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_d_isoflux_boundary_dz: Array2<f64> = isoflux_boundary_static.greens_d_sensor_dz.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_isoflux_boundary_pf: Array2<f64> = isoflux_boundary_static.greens_with_pf.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_isoflux_boundary_passives: Array2<f64> = isoflux_boundary_static.greens_with_passives.to_owned(); // shape = [n_passive_dof, n_sensors]
+        let greens_isoflux_boundary_grid: &Array2<f64> = &isoflux_boundary_static.greens_with_grid; // shape = [n_z*n_r, n_sensors]
+        let greens_d_isoflux_boundary_dz: &Array2<f64> = &isoflux_boundary_static.greens_d_sensor_dz; // shape = [n_z*n_r, n_sensors]
+        let greens_isoflux_boundary_pf: &Array2<f64> = &isoflux_boundary_static.greens_with_pf; // shape = [n_z*n_r, n_sensors]
+        let greens_isoflux_boundary_passives: &Array2<f64> = &isoflux_boundary_static.greens_with_passives; // shape = [n_passive_dof, n_sensors]
 
-        let greens_magnetic_axis_grid: Array2<f64> = magnetic_axis_static.greens_with_grid.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_d_magnetic_axis_dz: Array2<f64> = magnetic_axis_static.greens_d_sensor_dz.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_magnetic_axis_pf: Array2<f64> = magnetic_axis_static.greens_with_pf.to_owned(); // shape = [n_z*n_r, n_sensors]
-        let greens_magnetic_axis_passives: Array2<f64> = magnetic_axis_static.greens_with_passives.to_owned(); // shape = [n_passive_dof, n_sensors]
+        let greens_magnetic_axis_grid: &Array2<f64> = &magnetic_axis_static.greens_with_grid; // shape = [n_z*n_r, n_sensors]
+        let greens_d_magnetic_axis_dz: &Array2<f64> = &magnetic_axis_static.greens_d_sensor_dz; // shape = [n_z*n_r, n_sensors]
+        let greens_magnetic_axis_pf: &Array2<f64> = &magnetic_axis_static.greens_with_pf; // shape = [n_z*n_r, n_sensors]
+        let greens_magnetic_axis_passives: &Array2<f64> = &magnetic_axis_static.greens_with_passives; // shape = [n_passive_dof, n_sensors]
 
         // pf_coil_currents
         let pf_coil_currents: Array1<f64> = coils_dynamic.measured.to_owned();
@@ -761,9 +769,10 @@ impl<'a> GsSolution<'a> {
         let mut dof_values_previous: Array1<f64> = Array1::zeros(n_p_prime_dof + n_ff_prime_dof + n_passive_dof + 1);
         let mut psi_a_previous: f64 = 0.0; // needed to calculate gs-error
 
-        // Precompute the reorganised Greens tables for `calculate_psi_and_derivatives`
-        // (they do not change between iterations);  timing: 240ms, with [n_r, n_z]=[81, 321]
-        let psi_and_derivatives_greens: PsiAndDerivativesGreens = PsiAndDerivativesGreens::new(plasma);
+        // The reorganised Greens tables for `calculate_psi_and_derivatives` and the inside-vessel mask
+        // do not change between iterations or time-slices; they are calculated once in `solve_grad_shafranov`
+        let psi_and_derivatives_greens: &PsiAndDerivativesGreens = self.psi_and_derivatives_greens;
+        let mask_vessel_2d: &Array2<bool> = self.mask_vessel_2d;
 
         // Iteration loop
         'iteration_loop: for i_iter in 0..self.n_iter_max {
@@ -774,7 +783,7 @@ impl<'a> GsSolution<'a> {
 
             // Updates `psi` and all of its derivatives (including the `delta_z` vertical stability correction);
             // timing: 350ms, with [n_r, n_z]=[81, 321]
-            self.calculate_psi_and_derivatives(&psi_and_derivatives_greens);
+            self.calculate_psi_and_derivatives(psi_and_derivatives_greens);
             let psi_2d: Array2<f64> = self.psi_2d.to_owned();
             let d_psi_d_r_2d: Array2<f64> = self.d_psi_d_r_2d.to_owned();
             let d_psi_d_z_2d: Array2<f64> = self.d_psi_d_z_2d.to_owned();
@@ -849,6 +858,7 @@ impl<'a> GsSolution<'a> {
                 &limit_pts_z,
                 &vessel_r,
                 &vessel_z,
+                mask_vessel_2d,
                 self.r_mag,
                 self.z_mag,
             );

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -612,8 +612,9 @@ impl<'a> GsSolution<'a> {
         let vessel_z: Array1<f64> = plasma.results.get("vessel").get("z").unwrap_array1();
 
         // Degrees of freedom
-        let passives_shape: &[usize] = bp_probes_static.greens_with_passives.shape();
-        let n_passive_dof: usize = passives_shape[0];
+        // Number of passive degrees of freedom, from the passives themselves (the sensor tables are
+        // empty when a sensor type has no included sensors)
+        let n_passive_dof: usize = self.passive_regularisations.ncols();
         let n_p_prime_dof: usize = p_prime_source_function.source_function_n_dof();
         let n_ff_prime_dof: usize = ff_prime_source_function.source_function_n_dof();
         let n_iter_no_vertical_feedback: usize = self.n_iter_no_vertical_feedback;

--- a/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/gs_solution.rs
@@ -1,4 +1,5 @@
 use super::Error;
+use super::plasma_greens_spectra::PlasmaGreensSpectra;
 use crate::Plasma;
 use crate::plasma_geometry;
 use crate::plasma_geometry::BoundaryContour;
@@ -10,13 +11,10 @@ use crate::plasma_geometry::find_magnetic_axis;
 use crate::plasma_geometry::find_stationary_points_using_winding_number;
 use crate::sensors::{SensorsDynamic, SensorsStatic};
 use crate::source_functions::SourceFunctionTraits;
-use faer::linalg::matmul::matmul;
 use faer::linalg::solvers::{SolveLstsq, Svd as FaerSvd};
-use faer::mat::MatRef;
-use faer::{Accum, Par};
 use geo::{Contains, Coord, LineString, Point, Polygon};
 use ndarray::Axis;
-use ndarray::{Array1, Array2, Array3, ArrayView2, concatenate, s};
+use ndarray::{Array1, Array2, Array3, ArrayView2, s};
 use ndarray_stats::QuantileExt;
 use std::f64::consts::PI;
 use std::sync::Arc;
@@ -280,37 +278,24 @@ mod tests {
 
 /// Greens tables reorganised for `calculate_psi_and_derivatives`.
 ///
-/// Precomputed **once per time-slice** (the tables do not change between Picard iterations),
-/// while `calculate_psi_and_derivatives` is called **every** iteration.
+/// Precomputed **once per reconstruction** (the tables depend only on the grid, coils and passives)
+/// and shared by every time-slice, while `calculate_psi_and_derivatives` is called **every** Picard iteration.
 ///
 /// The expensive part of `calculate_psi_and_derivatives` is the plasma grid-to-grid convolution:
 /// ```text
 ///     field[(i_z, i_r)] = sum_{i_cur_z, i_cur_r} g[(|i_z - i_cur_z|, i_r, i_cur_r)] * j_2d[(i_cur_z, i_cur_r)] * d_area
 /// ```
-/// Because the Greens table only depends on the **vertical offset** `i_offset_z = |i_z - i_cur_z|`,
-/// the convolution can be reorganised into a single matrix multiplication:
-/// ```text
-///     field = w @ g_plasma_by_offset
-/// ```
-/// where row `i_z` of `w` gathers, for each `(i_offset_z, i_cur_r)`, the (at most two) current
-/// sources which see grid point `i_z` at that offset: `j_2d[(i_z - i_offset_z, i_cur_r)]` and
-/// `j_2d[(i_z + i_offset_z, i_cur_r)]`. Kernels which are **even** in `z - z_current_source`
-/// (`psi`, `d_psi_d_r`, `d2_psi_d_r2`, `d2_psi_d_z2`, `d3_psi_d_r_d_z2`) take the sum of the two
-/// sources; kernels which are **odd** (`d_psi_d_z`, `d2_psi_d_r_d_z`, `d3_psi_d_r2_d_z`,
-/// `d3_psi_d_z3`) take the difference. `w` is built fresh each iteration (it depends on `j_2d`), which is cheap;
-/// the GEMM is done with `faer`.
+/// Because the Greens table only depends on the **vertical offset** `|i_z - i_cur_z|`, this is a
+/// one-dimensional convolution along `z` for every radial pair `(i_r, i_cur_r)`, which is evaluated
+/// with FFTs by `PlasmaGreensSpectra` (the kernel spectra are stored here). Kernels which are
+/// **even** in `z - z_current_source` (`psi`, `d_psi_d_r`, `d2_psi_d_r2`, `d2_psi_d_z2`,
+/// `d3_psi_d_r_d_z2`) and kernels which are **odd** (`d_psi_d_z`, `d2_psi_d_r_d_z`,
+/// `d3_psi_d_r2_d_z`, `d3_psi_d_z3`) are returned as two column-wise concatenated blocks.
 ///
-/// The even kernels and the odd kernels are each concatenated column-wise, so the plasma
-/// contribution to all nine fields costs exactly two GEMMs.
+/// The PF coil and passive tables are small matrix-vector products and are kept as dense matrices.
 pub struct PsiAndDerivativesGreens {
-    /// Plasma grid-to-grid, even kernels, concatenated column-wise in the order
-    /// [`psi`, `d_psi_d_r`, `d2_psi_d_r2`, `d2_psi_d_z2`, `d3_psi_d_r_d_z2`];
-    /// rows = (i_offset_z * n_r + i_cur_r); shape = (n_z * n_r, 5 * n_r)
-    g_even_plasma_by_offset: Array2<f64>,
-    /// Plasma grid-to-grid, odd kernels, concatenated column-wise in the order
-    /// [`d_psi_d_z`, `d2_psi_d_r_d_z`, `d3_psi_d_r2_d_z`, `d3_psi_d_z3`];
-    /// rows = (i_offset_z * n_r + i_cur_r); shape = (n_z * n_r, 4 * n_r)
-    g_odd_plasma_by_offset: Array2<f64>,
+    /// Fourier transforms of the plasma grid-to-grid kernels, for the convolution along `z`
+    plasma_spectra: PlasmaGreensSpectra,
     /// PF coils; each shape = (n_z * n_r, n_pf)
     g_d_psi_d_r_coils_matrix: Array2<f64>,
     g_d_psi_d_z_coils_matrix: Array2<f64>,
@@ -337,61 +322,8 @@ impl PsiAndDerivativesGreens {
         let n_r: usize = plasma.results.get("grid").get("n_r").unwrap_usize();
         let n_z: usize = plasma.results.get("grid").get("n_z").unwrap_usize();
 
-        // Plasma grid-to-grid tables; stored shape = (n_z * n_r, n_r), which unflattens to
-        // (i_offset_z, i_r, i_cur_r). Permute to (i_offset_z, i_cur_r, i_r) and re-flatten so
-        // that rows = (i_offset_z, i_cur_r) match the columns of `w`, and columns = i_r
-        let permute_to_by_offset = |g_flat: Array2<f64>| -> Array2<f64> {
-            let g_3d: Array3<f64> = g_flat
-                .to_shape((n_z, n_r, n_r))
-                .expect("PsiAndDerivativesGreens: failed to reshape grid_grid table into (n_z, n_r, n_r)")
-                .to_owned();
-            let g_3d_permuted: Array3<f64> = g_3d.permuted_axes([0, 2, 1]);
-            let g_by_offset: Array2<f64> = g_3d_permuted
-                .as_standard_layout()
-                .to_shape((n_z * n_r, n_r))
-                .expect("PsiAndDerivativesGreens: failed to flatten permuted table into (n_z * n_r, n_r)")
-                .to_owned();
-            return g_by_offset;
-        };
-
-        let grid_grid = |key: &str| -> Array2<f64> { permute_to_by_offset(plasma.results.get("greens").get("grid_grid").get(key).unwrap_array2()) };
-        let g_psi_plasma_by_offset: Array2<f64> = grid_grid("psi");
-        let g_d_psi_d_r_plasma_by_offset: Array2<f64> = grid_grid("d_psi_d_r");
-        let g_d_psi_d_z_plasma_by_offset: Array2<f64> = grid_grid("d_psi_d_z");
-        let g_d2_psi_d_r2_plasma_by_offset: Array2<f64> = grid_grid("d2_psi_d_r2");
-        let g_d2_psi_d_r_d_z_plasma_by_offset: Array2<f64> = grid_grid("d2_psi_d_r_d_z");
-        let g_d2_psi_d_z2_plasma_by_offset: Array2<f64> = grid_grid("d2_psi_d_z2");
-        let g_d3_psi_d_r2_d_z_plasma_by_offset: Array2<f64> = grid_grid("d3_psi_d_r2_d_z");
-        let g_d3_psi_d_r_d_z2_plasma_by_offset: Array2<f64> = grid_grid("d3_psi_d_r_d_z2");
-        let g_d3_psi_d_z3_plasma_by_offset: Array2<f64> = grid_grid("d3_psi_d_z3");
-
-        // Concatenate per parity, so each parity is a single GEMM
-        // (`as_standard_layout` because `concatenate` does not guarantee a C-contiguous result)
-        let g_even_plasma_by_offset: Array2<f64> = concatenate(
-            Axis(1),
-            &[
-                g_psi_plasma_by_offset.view(),
-                g_d_psi_d_r_plasma_by_offset.view(),
-                g_d2_psi_d_r2_plasma_by_offset.view(),
-                g_d2_psi_d_z2_plasma_by_offset.view(),
-                g_d3_psi_d_r_d_z2_plasma_by_offset.view(),
-            ],
-        )
-        .expect("PsiAndDerivativesGreens: failed to concatenate even kernels")
-        .as_standard_layout()
-        .to_owned();
-        let g_odd_plasma_by_offset: Array2<f64> = concatenate(
-            Axis(1),
-            &[
-                g_d_psi_d_z_plasma_by_offset.view(),
-                g_d2_psi_d_r_d_z_plasma_by_offset.view(),
-                g_d3_psi_d_r2_d_z_plasma_by_offset.view(),
-                g_d3_psi_d_z3_plasma_by_offset.view(),
-            ],
-        )
-        .expect("PsiAndDerivativesGreens: failed to concatenate odd kernels")
-        .as_standard_layout()
-        .to_owned();
+        // Plasma grid-to-grid tables, transformed along `z` (see `PlasmaGreensSpectra`)
+        let plasma_spectra: PlasmaGreensSpectra = PlasmaGreensSpectra::new(plasma);
 
         // PF coils: (n_z, n_r, n_pf) flattens to (n_z * n_r, n_pf)
         let coils_matrix = |key: &str| -> Array2<f64> {
@@ -423,8 +355,7 @@ impl PsiAndDerivativesGreens {
         let g_d3_psi_d_z3_passives_matrix: Array2<f64> = plasma.get_greens_passive_grid_d3_psi_d_z3();
 
         return Self {
-            g_even_plasma_by_offset,
-            g_odd_plasma_by_offset,
+            plasma_spectra,
             g_d_psi_d_r_coils_matrix,
             g_d_psi_d_z_coils_matrix,
             g_d2_psi_d_r2_coils_matrix,
@@ -1583,8 +1514,8 @@ impl<'a> GsSolution<'a> {
     ///
     /// Only `psi` and its derivatives are used; `br` and `bz` do not appear.
     ///
-    /// The plasma contribution is calculated with two GEMMs; see `PsiAndDerivativesGreens` for the
-    /// reorganisation of the convolution over current sources.
+    /// The plasma contribution is a convolution along `z` for every radial pair, evaluated with FFTs;
+    /// see `PlasmaGreensSpectra`.
     pub fn calculate_psi_and_derivatives(&mut self, greens_tables: &PsiAndDerivativesGreens) {
         // Unpack from self
         let plasma: &Plasma = self.plasma;
@@ -1633,87 +1564,12 @@ impl<'a> GsSolution<'a> {
         let d3_psi_d_r_d_z2_2d_passives: Array2<f64> = contract(&greens_tables.g_d3_psi_d_r_d_z2_passives_matrix, passive_dof_values);
         let d3_psi_d_z3_2d_passives: Array2<f64> = contract(&greens_tables.g_d3_psi_d_z3_passives_matrix, passive_dof_values);
 
-        // Plasma: two GEMMs over the reorganised tables (see `PsiAndDerivativesGreens`).
-        // `w_even` and `w_odd` gather the current sources by (vertical offset, source radius):
-        //     w_even[(i_z, i_offset_z * n_r + i_cur_r)] = d_area * (j_below + j_above)
-        //     w_odd[(i_z, i_offset_z * n_r + i_cur_r)]  = d_area * (j_below - j_above)
-        // where `j_below = j_2d[(i_z - i_offset_z, i_cur_r)]` (a source below the grid point) and
-        // `j_above = j_2d[(i_z + i_offset_z, i_cur_r)]` (a source at or above the grid point).
-        // The odd kernels (`d_psi_d_z`, `d2_psi_d_r_d_z`) change sign with the source side:
-        // sources with `i_z <= i_cur_z` enter with -1
-        let mut w_even: Array2<f64> = Array2::zeros((n_z, n_z * n_r));
-        let mut w_odd: Array2<f64> = Array2::zeros((n_z, n_z * n_r));
-        for i_z in 0..n_z {
-            for i_offset_z in 0..n_z {
-                let i_column_start: usize = i_offset_z * n_r;
-
-                // Source below the grid point: i_cur_z = i_z - i_offset_z (excluding i_offset_z = 0)
-                if i_offset_z > 0 && i_z >= i_offset_z {
-                    let i_cur_z: usize = i_z - i_offset_z;
-                    for i_cur_r in 0..n_r {
-                        let j_this: f64 = d_area * j_2d[(i_cur_z, i_cur_r)];
-                        w_even[(i_z, i_column_start + i_cur_r)] += j_this;
-                        w_odd[(i_z, i_column_start + i_cur_r)] += j_this;
-                    }
-                }
-
-                // Source at or above the grid point: i_cur_z = i_z + i_offset_z (including i_offset_z = 0)
-                if i_z + i_offset_z < n_z {
-                    let i_cur_z: usize = i_z + i_offset_z;
-                    for i_cur_r in 0..n_r {
-                        let j_this: f64 = d_area * j_2d[(i_cur_z, i_cur_r)];
-                        w_even[(i_z, i_column_start + i_cur_r)] += j_this;
-                        w_odd[(i_z, i_column_start + i_cur_r)] -= j_this;
-                    }
-                }
-            }
-        }
-
-        // GEMMs, using `faer` (multi-threaded)
-        let mut plasma_even: faer::Mat<f64> = faer::Mat::zeros(n_z, 5 * n_r);
-        matmul(
-            plasma_even.as_mut(),
-            Accum::Replace,
-            MatRef::from_row_major_slice(
-                w_even.as_slice().expect("calculate_psi_and_derivatives: `w_even` is not contiguous"),
-                n_z,
-                n_z * n_r,
-            ),
-            MatRef::from_row_major_slice(
-                greens_tables
-                    .g_even_plasma_by_offset
-                    .as_slice()
-                    .expect("calculate_psi_and_derivatives: `g_even_plasma_by_offset` is not contiguous"),
-                n_z * n_r,
-                5 * n_r,
-            ),
-            1.0,
-            Par::rayon(0),
-        );
-        let mut plasma_odd: faer::Mat<f64> = faer::Mat::zeros(n_z, 4 * n_r);
-        matmul(
-            plasma_odd.as_mut(),
-            Accum::Replace,
-            MatRef::from_row_major_slice(
-                w_odd.as_slice().expect("calculate_psi_and_derivatives: `w_odd` is not contiguous"),
-                n_z,
-                n_z * n_r,
-            ),
-            MatRef::from_row_major_slice(
-                greens_tables
-                    .g_odd_plasma_by_offset
-                    .as_slice()
-                    .expect("calculate_psi_and_derivatives: `g_odd_plasma_by_offset` is not contiguous"),
-                n_z * n_r,
-                4 * n_r,
-            ),
-            1.0,
-            Par::rayon(0),
-        );
+        // Plasma: FFT convolution along `z` (see `PlasmaGreensSpectra`); the even and odd kernels are
+        // returned as column-wise concatenated blocks, shape = (n_z, 5 * n_r) and (n_z, 4 * n_r)
+        let (plasma_even, plasma_odd): (Array2<f64>, Array2<f64>) = greens_tables.plasma_spectra.convolve(j_2d, d_area);
 
         // Assemble the unshifted fields (coils + passives + plasma).
-        // The `plasma_even` / `plasma_odd` column blocks follow the concatenation order
-        // documented on `PsiAndDerivativesGreens`
+        // The `plasma_even` / `plasma_odd` column blocks follow the kernel order documented on `PlasmaGreensSpectra`
         let mut psi_2d_unshifted: Array2<f64> = Array2::from_elem((n_z, n_r), f64::NAN);
         let mut d_psi_d_r_2d_unshifted: Array2<f64> = Array2::from_elem((n_z, n_r), f64::NAN);
         let mut d_psi_d_z_2d_unshifted: Array2<f64> = Array2::from_elem((n_z, n_r), f64::NAN);

--- a/rust/gsfit_rs/src/grad_shafranov/mod.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/mod.rs
@@ -6,6 +6,7 @@ mod gs_solution;
 // Expose functions to public
 pub use grad_shafranov_solver::solve_grad_shafranov;
 pub use gs_solution::GsSolution;
+pub mod plasma_greens_spectra;
 
 // Define the possible **external** failures this module can produce
 #[derive(Debug)]

--- a/rust/gsfit_rs/src/grad_shafranov/plasma_greens_spectra.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/plasma_greens_spectra.rs
@@ -319,22 +319,18 @@ mod tests {
     use super::*;
     use ndarray::Array3;
 
-    /// Direct evaluation of the double sum, for comparison with the FFT convolution
-    fn direct_sum(table: &Array3<f64>, j_2d: &Array2<f64>, d_area: f64, is_odd: bool) -> Array2<f64> {
+    /// Direct evaluation of the double sum at one grid point, for comparison with the FFT convolution
+    fn direct_sum_at(table: &Array3<f64>, j_2d: &Array2<f64>, d_area: f64, is_odd: bool, i_z: usize, i_r: usize) -> f64 {
         let (n_z, n_r, _): (usize, usize, usize) = table.dim();
-        let mut field: Array2<f64> = Array2::zeros((n_z, n_r));
-        for i_z in 0..n_z {
-            for i_r in 0..n_r {
-                for i_cur_z in 0..n_z {
-                    for i_cur_r in 0..n_r {
-                        let i_offset_z: usize = i_z.abs_diff(i_cur_z);
-                        let mut sign: f64 = 1.0;
-                        if is_odd && i_cur_z >= i_z {
-                            sign = -1.0;
-                        }
-                        field[(i_z, i_r)] += sign * table[(i_offset_z, i_r, i_cur_r)] * j_2d[(i_cur_z, i_cur_r)] * d_area;
-                    }
+        let mut field: f64 = 0.0;
+        for i_cur_z in 0..n_z {
+            for i_cur_r in 0..n_r {
+                let i_offset_z: usize = i_z.abs_diff(i_cur_z);
+                let mut sign: f64 = 1.0;
+                if is_odd && i_cur_z >= i_z {
+                    sign = -1.0;
                 }
+                field += sign * table[(i_offset_z, i_r, i_cur_r)] * j_2d[(i_cur_z, i_cur_r)] * d_area;
             }
         }
         field
@@ -356,10 +352,19 @@ mod tests {
 
     #[test]
     fn test_convolve_matches_direct_sum() {
-        let n_r: usize = 5;
-        let n_z: usize = 7;
+        convolve_matches_direct_sum(5, 7, 12345);
+    }
+
+    /// The MAST-U example grid (65 x 129, FFT length 270) and the ST40 default grid (81 x 161, FFT length 324)
+    #[test]
+    fn test_convolve_matches_direct_sum_at_production_sizes() {
+        convolve_matches_direct_sum(65, 129, 777);
+        convolve_matches_direct_sum(81, 161, 999);
+    }
+
+    fn convolve_matches_direct_sum(n_r: usize, n_z: usize, seed_start: u64) {
         let d_area: f64 = 0.25;
-        let mut seed: u64 = 12345;
+        let mut seed: u64 = seed_start;
 
         let mut even_tables: Vec<Array3<f64>> = Vec::new();
         for _i_kernel in 0..N_EVEN_KERNELS {
@@ -397,22 +402,47 @@ mod tests {
         let spectra: PlasmaGreensSpectra = PlasmaGreensSpectra::from_tables(n_r, n_z, &even_views, &odd_views);
         let (plasma_even, plasma_odd): (Array2<f64>, Array2<f64>) = spectra.convolve(&j_2d, d_area);
 
-        for i_kernel in 0..N_EVEN_KERNELS {
-            let expected: Array2<f64> = direct_sum(&even_tables[i_kernel], &j_2d, d_area, false);
+        // Check every grid point on small grids, and a sample of grid points on production-sized grids
+        // (the direct double sum is O(n_z^2 n_r^2))
+        let n_points_max: usize = 200;
+        let mut points: Vec<(usize, usize)> = Vec::new();
+        if n_z * n_r <= n_points_max {
             for i_z in 0..n_z {
                 for i_r in 0..n_r {
-                    let difference: f64 = (plasma_even[(i_z, i_kernel * n_r + i_r)] - expected[(i_z, i_r)]).abs();
-                    assert!(difference < 1.0e-12, "even kernel {i_kernel}: difference {difference} at ({i_z}, {i_r})");
+                    points.push((i_z, i_r));
                 }
+            }
+        } else {
+            for _i_point in 0..n_points_max {
+                let i_z: usize = ((pseudo_random(&mut seed) + 1.0) / 2.0 * (n_z as f64)) as usize % n_z;
+                let i_r: usize = ((pseudo_random(&mut seed) + 1.0) / 2.0 * (n_r as f64)) as usize % n_r;
+                points.push((i_z, i_r));
+            }
+            // Always include the corners and the centre
+            points.push((0, 0));
+            points.push((n_z - 1, n_r - 1));
+            points.push((n_z / 2, n_r / 2));
+        }
+        let scale_even: f64 = plasma_even.iter().fold(0.0_f64, |maximum, value| maximum.max(value.abs()));
+        let scale_odd: f64 = plasma_odd.iter().fold(0.0_f64, |maximum, value| maximum.max(value.abs()));
+        for i_kernel in 0..N_EVEN_KERNELS {
+            for &(i_z, i_r) in &points {
+                let expected: f64 = direct_sum_at(&even_tables[i_kernel], &j_2d, d_area, false, i_z, i_r);
+                let difference: f64 = (plasma_even[(i_z, i_kernel * n_r + i_r)] - expected).abs();
+                assert!(
+                    difference < 1.0e-12 * scale_even.max(1.0),
+                    "even kernel {i_kernel}: difference {difference} at ({i_z}, {i_r})"
+                );
             }
         }
         for i_kernel in 0..N_ODD_KERNELS {
-            let expected: Array2<f64> = direct_sum(&odd_tables[i_kernel], &j_2d, d_area, true);
-            for i_z in 0..n_z {
-                for i_r in 0..n_r {
-                    let difference: f64 = (plasma_odd[(i_z, i_kernel * n_r + i_r)] - expected[(i_z, i_r)]).abs();
-                    assert!(difference < 1.0e-12, "odd kernel {i_kernel}: difference {difference} at ({i_z}, {i_r})");
-                }
+            for &(i_z, i_r) in &points {
+                let expected: f64 = direct_sum_at(&odd_tables[i_kernel], &j_2d, d_area, true, i_z, i_r);
+                let difference: f64 = (plasma_odd[(i_z, i_kernel * n_r + i_r)] - expected).abs();
+                assert!(
+                    difference < 1.0e-12 * scale_odd.max(1.0),
+                    "odd kernel {i_kernel}: difference {difference} at ({i_z}, {i_r})"
+                );
             }
         }
     }

--- a/rust/gsfit_rs/src/grad_shafranov/plasma_greens_spectra.rs
+++ b/rust/gsfit_rs/src/grad_shafranov/plasma_greens_spectra.rs
@@ -1,0 +1,419 @@
+//! Plasma grid-to-grid Green's convolution, evaluated with FFTs along the vertical axis.
+//!
+//! The poloidal flux (and its derivatives) produced on the `(R, Z)` grid by the plasma current is
+//! ```text
+//!     field_k[(i_z, i_r)] = sum_{i_cur_z, i_cur_r} g_k[(|i_z - i_cur_z|, i_r, i_cur_r)] * j_2d[(i_cur_z, i_cur_r)] * d_area
+//! ```
+//! because the grid is uniform in `z`, so a Green's table only depends on the vertical **offset**
+//! between the grid point and the current source (see `Plasma::new`). For every pair of radial
+//! indices `(i_r, i_cur_r)` this is a one-dimensional convolution along `z` of the current column
+//! `j_2d[(.., i_cur_r)]` with the kernel `g_k[(.., i_r, i_cur_r)]`, extended to negative offsets as
+//! an even function (`psi`, `d_psi_d_r`, `d2_psi_d_r2`, `d2_psi_d_z2`, `d3_psi_d_r_d_z2`) or an odd
+//! function (`d_psi_d_z`, `d2_psi_d_r_d_z`, `d3_psi_d_r2_d_z`, `d3_psi_d_z3`; the sign is that of
+//! `i_z - i_cur_z`, i.e. sources below the grid point count positive).
+//!
+//! Convolutions are products in Fourier space, so the kernels are transformed **once** per
+//! reconstruction (they depend only on the grid), and each Picard iteration only transforms the
+//! current columns, multiplies, and transforms back:
+//! ```text
+//!     field_k[(.., i_r)] = irfft( sum_{i_cur_r} G_k[(i_r, i_cur_r, ..)] * rfft(j_2d[(.., i_cur_r)] * d_area) )
+//! ```
+//! Zero-padding to `fft_length >= 2 * n_z - 1` makes the circular convolution equal to the linear one.
+//! Even kernels have purely real spectra and odd kernels purely imaginary ones, so one `f64` per
+//! frequency bin is stored for each kernel and radial pair.
+//!
+//! Per iteration this costs `O(n_r^2 * n_z * log(n_z))` instead of the `O(n_r^2 * n_z^2)` of the
+//! dense matrix product it replaces; the result is the same sum evaluated in a different
+//! (floating-point rounding level) order.
+use crate::Plasma;
+use ndarray::{Array2, Array3, ArrayView3};
+use rayon::prelude::*;
+use realfft::num_complex::Complex;
+use realfft::{ComplexToReal, RealFftPlanner, RealToComplex};
+use std::sync::Arc;
+
+/// Even kernels, in the column-block order produced by `convolve`
+pub const EVEN_KERNEL_NAMES: [&str; 5] = ["psi", "d_psi_d_r", "d2_psi_d_r2", "d2_psi_d_z2", "d3_psi_d_r_d_z2"];
+/// Odd kernels, in the column-block order produced by `convolve`
+pub const ODD_KERNEL_NAMES: [&str; 4] = ["d_psi_d_z", "d2_psi_d_r_d_z", "d3_psi_d_r2_d_z", "d3_psi_d_z3"];
+
+const N_EVEN_KERNELS: usize = 5;
+const N_ODD_KERNELS: usize = 4;
+
+/// Fourier transforms of the plasma grid-to-grid Green's tables (see the module documentation)
+pub struct PlasmaGreensSpectra {
+    n_r: usize,
+    n_z: usize,
+    fft_length: usize,
+    n_bins: usize,
+    /// Real part of the even-kernel spectra, divided by `fft_length` (the inverse transform is unnormalised);
+    /// index = `((i_kernel * n_r + i_r) * n_r + i_cur_r) * n_bins + i_bin`
+    even_spectra: Vec<f64>,
+    /// Imaginary part of the odd-kernel spectra, divided by `fft_length`; same indexing as `even_spectra`
+    odd_spectra: Vec<f64>,
+    fft_forward: Arc<dyn RealToComplex<f64>>,
+    fft_inverse: Arc<dyn ComplexToReal<f64>>,
+}
+
+/// Smallest even integer `>= n_min` whose prime factors are all 2, 3 or 5, so that the FFT is fast
+fn smooth_even_fft_length(n_min: usize) -> usize {
+    let n_candidate_max: usize = 2 * n_min.max(2) + 2;
+    for n_candidate in n_min.max(2)..=n_candidate_max {
+        if n_candidate % 2 != 0 {
+            continue;
+        }
+        let mut remainder: usize = n_candidate;
+        for prime in [2, 3, 5] {
+            let n_divisions_max: usize = 64;
+            for _i_division in 0..n_divisions_max {
+                if remainder % prime == 0 {
+                    remainder /= prime;
+                } else {
+                    break;
+                }
+            }
+        }
+        if remainder == 1 {
+            return n_candidate;
+        }
+    }
+    // Unreachable in practice (a power of two always lies within the search range); fall back to the next power of two
+    return n_min.next_power_of_two();
+}
+
+impl PlasmaGreensSpectra {
+    /// Build the spectra from the `greens/grid_grid` tables stored in `plasma`
+    pub fn new(plasma: &Plasma) -> Self {
+        let n_r: usize = plasma.results.get("grid").get("n_r").unwrap_usize();
+        let n_z: usize = plasma.results.get("grid").get("n_z").unwrap_usize();
+
+        // Stored shape = (n_z * n_r, n_r), which unflattens to (i_offset_z, i_r, i_cur_r)
+        let grid_grid = |key: &str| -> Array3<f64> {
+            plasma
+                .results
+                .get("greens")
+                .get("grid_grid")
+                .get(key)
+                .unwrap_array2()
+                .to_shape((n_z, n_r, n_r))
+                .expect("PlasmaGreensSpectra: failed to reshape grid_grid table into (n_z, n_r, n_r)")
+                .to_owned()
+        };
+        let mut even_tables: Vec<Array3<f64>> = Vec::with_capacity(N_EVEN_KERNELS);
+        for kernel_name in EVEN_KERNEL_NAMES {
+            even_tables.push(grid_grid(kernel_name));
+        }
+        let mut odd_tables: Vec<Array3<f64>> = Vec::with_capacity(N_ODD_KERNELS);
+        for kernel_name in ODD_KERNEL_NAMES {
+            odd_tables.push(grid_grid(kernel_name));
+        }
+        let even_views: Vec<ArrayView3<f64>> = even_tables.iter().map(|table| table.view()).collect();
+        let odd_views: Vec<ArrayView3<f64>> = odd_tables.iter().map(|table| table.view()).collect();
+
+        return Self::from_tables(n_r, n_z, &even_views, &odd_views);
+    }
+
+    /// Build the spectra from Green's tables of shape `(n_z, n_r, n_r)` = `(i_offset_z, i_r, i_cur_r)`
+    ///
+    /// # Arguments
+    /// * `n_r` - number of radial grid points, [dimensionless]
+    /// * `n_z` - number of vertical grid points, [dimensionless]
+    /// * `even_tables` - the five kernels which are even in `z - z_current_source`, in `EVEN_KERNEL_NAMES` order
+    /// * `odd_tables` - the four kernels which are odd in `z - z_current_source`, in `ODD_KERNEL_NAMES` order
+    pub fn from_tables(n_r: usize, n_z: usize, even_tables: &[ArrayView3<f64>], odd_tables: &[ArrayView3<f64>]) -> Self {
+        assert!(
+            even_tables.len() == N_EVEN_KERNELS,
+            "PlasmaGreensSpectra: expected {N_EVEN_KERNELS} even kernels"
+        );
+        assert!(odd_tables.len() == N_ODD_KERNELS, "PlasmaGreensSpectra: expected {N_ODD_KERNELS} odd kernels");
+        for table in even_tables.iter().chain(odd_tables.iter()) {
+            assert!(table.dim() == (n_z, n_r, n_r), "PlasmaGreensSpectra: Green's table has the wrong shape");
+        }
+
+        // Zero-padding so the circular convolution equals the linear convolution over all offsets
+        let fft_length: usize = smooth_even_fft_length(2 * n_z - 1);
+        let n_bins: usize = fft_length / 2 + 1;
+
+        let mut planner: RealFftPlanner<f64> = RealFftPlanner::<f64>::new();
+        let fft_forward: Arc<dyn RealToComplex<f64>> = planner.plan_fft_forward(fft_length);
+        let fft_inverse: Arc<dyn ComplexToReal<f64>> = planner.plan_fft_inverse(fft_length);
+
+        // Transform every (kernel, i_r, i_cur_r) kernel column; the inverse transform's normalisation is folded in here
+        let normalisation: f64 = 1.0 / (fft_length as f64);
+        let transform_kernels = |tables: &[ArrayView3<f64>], is_odd: bool| -> Vec<f64> {
+            let n_kernels: usize = tables.len();
+            let spectra_per_row: Vec<Vec<f64>> = (0..n_kernels * n_r)
+                .into_par_iter()
+                .map(|i_kernel_and_r: usize| {
+                    let i_kernel: usize = i_kernel_and_r / n_r;
+                    let i_r: usize = i_kernel_and_r % n_r;
+                    let table: &ArrayView3<f64> = &tables[i_kernel];
+                    let mut spectra_this_row: Vec<f64> = vec![0.0; n_r * n_bins];
+                    let mut sequence: Vec<f64> = fft_forward.make_input_vec();
+                    let mut spectrum: Vec<Complex<f64>> = fft_forward.make_output_vec();
+                    for i_cur_r in 0..n_r {
+                        // Kernel as a function of the signed offset `m = i_z - i_cur_z`, stored circularly:
+                        // index `m` for `m >= 0`, index `fft_length + m` for `m < 0`
+                        for value in sequence.iter_mut() {
+                            *value = 0.0;
+                        }
+                        if is_odd {
+                            // Odd kernels: sources below the grid point (`m > 0`) count positive, sources at or
+                            // above (`m <= 0`) count negative, matching the sign convention of the direct sum.
+                            // At zero offset an odd kernel vanishes by symmetry, so its spectrum is purely imaginary.
+                            let g_zero_offset: f64 = table[(0, i_r, i_cur_r)];
+                            assert!(
+                                g_zero_offset == 0.0,
+                                "PlasmaGreensSpectra: odd Green's kernel is not zero at zero vertical offset ({g_zero_offset})"
+                            );
+                            sequence[0] = -g_zero_offset;
+                            for i_offset_z in 1..n_z {
+                                let g_value: f64 = table[(i_offset_z, i_r, i_cur_r)];
+                                sequence[i_offset_z] = g_value;
+                                sequence[fft_length - i_offset_z] = -g_value;
+                            }
+                        } else {
+                            sequence[0] = table[(0, i_r, i_cur_r)];
+                            for i_offset_z in 1..n_z {
+                                let g_value: f64 = table[(i_offset_z, i_r, i_cur_r)];
+                                sequence[i_offset_z] = g_value;
+                                sequence[fft_length - i_offset_z] = g_value;
+                            }
+                        }
+                        fft_forward
+                            .process(&mut sequence, &mut spectrum)
+                            .expect("PlasmaGreensSpectra: forward FFT of a Green's kernel failed");
+                        for i_bin in 0..n_bins {
+                            spectra_this_row[i_cur_r * n_bins + i_bin] = if is_odd {
+                                spectrum[i_bin].im * normalisation
+                            } else {
+                                spectrum[i_bin].re * normalisation
+                            };
+                        }
+                    }
+                    spectra_this_row
+                })
+                .collect();
+            let mut spectra: Vec<f64> = Vec::with_capacity(n_kernels * n_r * n_r * n_bins);
+            for spectra_this_row in spectra_per_row {
+                spectra.extend_from_slice(&spectra_this_row);
+            }
+            spectra
+        };
+        let even_spectra: Vec<f64> = transform_kernels(even_tables, false);
+        let odd_spectra: Vec<f64> = transform_kernels(odd_tables, true);
+
+        return PlasmaGreensSpectra {
+            n_r,
+            n_z,
+            fft_length,
+            n_bins,
+            even_spectra,
+            odd_spectra,
+            fft_forward,
+            fft_inverse,
+        };
+    }
+
+    /// Plasma contribution to the nine fields, for the current density `j_2d`, shape = (n_z, n_r), [ampere / metre ** 2]
+    ///
+    /// # Returns
+    /// * `plasma_even` - the five even kernels concatenated column-wise in `EVEN_KERNEL_NAMES` order; shape = (n_z, 5 * n_r)
+    /// * `plasma_odd` - the four odd kernels concatenated column-wise in `ODD_KERNEL_NAMES` order; shape = (n_z, 4 * n_r)
+    pub fn convolve(&self, j_2d: &Array2<f64>, d_area: f64) -> (Array2<f64>, Array2<f64>) {
+        let n_r: usize = self.n_r;
+        let n_z: usize = self.n_z;
+        let n_bins: usize = self.n_bins;
+        let fft_length: usize = self.fft_length;
+        assert!(j_2d.dim() == (n_z, n_r), "PlasmaGreensSpectra::convolve: `j_2d` has the wrong shape");
+
+        // Spectra of the current columns; columns without current are skipped in the products below
+        let mut source_spectra: Vec<Complex<f64>> = vec![Complex::new(0.0, 0.0); n_r * n_bins];
+        let mut active_source_columns: Vec<usize> = Vec::with_capacity(n_r);
+        let mut sequence: Vec<f64> = self.fft_forward.make_input_vec();
+        let mut spectrum: Vec<Complex<f64>> = self.fft_forward.make_output_vec();
+        for i_cur_r in 0..n_r {
+            let mut column_has_current: bool = false;
+            for value in sequence.iter_mut() {
+                *value = 0.0;
+            }
+            for i_cur_z in 0..n_z {
+                let current: f64 = d_area * j_2d[(i_cur_z, i_cur_r)];
+                sequence[i_cur_z] = current;
+                if current != 0.0 {
+                    column_has_current = true;
+                }
+            }
+            if !column_has_current {
+                continue;
+            }
+            self.fft_forward
+                .process(&mut sequence, &mut spectrum)
+                .expect("PlasmaGreensSpectra::convolve: forward FFT of a current column failed");
+            source_spectra[i_cur_r * n_bins..(i_cur_r + 1) * n_bins].copy_from_slice(&spectrum);
+            active_source_columns.push(i_cur_r);
+        }
+
+        // One task per (kernel, i_r): accumulate the spectral products over the active current columns,
+        // then transform back; the first `n_z` samples of the padded result are the field column
+        let field_columns = |spectra: &Vec<f64>, n_kernels: usize, is_odd: bool| -> Vec<Vec<f64>> {
+            (0..n_kernels * n_r)
+                .into_par_iter()
+                .map(|i_kernel_and_r: usize| {
+                    let mut accumulator: Vec<Complex<f64>> = vec![Complex::new(0.0, 0.0); n_bins];
+                    for &i_cur_r in &active_source_columns {
+                        let i_start: usize = (i_kernel_and_r * n_r + i_cur_r) * n_bins;
+                        let kernel_spectrum: &[f64] = &spectra[i_start..i_start + n_bins];
+                        let source_spectrum: &[Complex<f64>] = &source_spectra[i_cur_r * n_bins..(i_cur_r + 1) * n_bins];
+                        if is_odd {
+                            // kernel spectrum = i * g_im; (i * g_im) * (s_re + i * s_im) = -g_im * s_im + i * g_im * s_re
+                            for i_bin in 0..n_bins {
+                                accumulator[i_bin].re -= kernel_spectrum[i_bin] * source_spectrum[i_bin].im;
+                                accumulator[i_bin].im += kernel_spectrum[i_bin] * source_spectrum[i_bin].re;
+                            }
+                        } else {
+                            for i_bin in 0..n_bins {
+                                accumulator[i_bin].re += kernel_spectrum[i_bin] * source_spectrum[i_bin].re;
+                                accumulator[i_bin].im += kernel_spectrum[i_bin] * source_spectrum[i_bin].im;
+                            }
+                        }
+                    }
+                    // A real signal has real DC and Nyquist bins; rounding leaves tiny imaginary parts which
+                    // the inverse real transform rejects, so they are cleared explicitly
+                    accumulator[0].im = 0.0;
+                    if fft_length % 2 == 0 {
+                        accumulator[n_bins - 1].im = 0.0;
+                    }
+                    let mut padded_field: Vec<f64> = self.fft_inverse.make_output_vec();
+                    self.fft_inverse
+                        .process(&mut accumulator, &mut padded_field)
+                        .expect("PlasmaGreensSpectra::convolve: inverse FFT failed");
+                    padded_field.truncate(n_z);
+                    padded_field
+                })
+                .collect()
+        };
+        let even_columns: Vec<Vec<f64>> = field_columns(&self.even_spectra, N_EVEN_KERNELS, false);
+        let odd_columns: Vec<Vec<f64>> = field_columns(&self.odd_spectra, N_ODD_KERNELS, true);
+
+        // Column block `i_kernel` holds kernel `i_kernel`, matching the layout consumed by `calculate_psi_and_derivatives`
+        let mut plasma_even: Array2<f64> = Array2::from_elem((n_z, N_EVEN_KERNELS * n_r), f64::NAN);
+        for i_kernel_and_r in 0..N_EVEN_KERNELS * n_r {
+            for i_z in 0..n_z {
+                plasma_even[(i_z, i_kernel_and_r)] = even_columns[i_kernel_and_r][i_z];
+            }
+        }
+        let mut plasma_odd: Array2<f64> = Array2::from_elem((n_z, N_ODD_KERNELS * n_r), f64::NAN);
+        for i_kernel_and_r in 0..N_ODD_KERNELS * n_r {
+            for i_z in 0..n_z {
+                plasma_odd[(i_z, i_kernel_and_r)] = odd_columns[i_kernel_and_r][i_z];
+            }
+        }
+
+        return (plasma_even, plasma_odd);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array3;
+
+    /// Direct evaluation of the double sum, for comparison with the FFT convolution
+    fn direct_sum(table: &Array3<f64>, j_2d: &Array2<f64>, d_area: f64, is_odd: bool) -> Array2<f64> {
+        let (n_z, n_r, _): (usize, usize, usize) = table.dim();
+        let mut field: Array2<f64> = Array2::zeros((n_z, n_r));
+        for i_z in 0..n_z {
+            for i_r in 0..n_r {
+                for i_cur_z in 0..n_z {
+                    for i_cur_r in 0..n_r {
+                        let i_offset_z: usize = i_z.abs_diff(i_cur_z);
+                        let mut sign: f64 = 1.0;
+                        if is_odd && i_cur_z >= i_z {
+                            sign = -1.0;
+                        }
+                        field[(i_z, i_r)] += sign * table[(i_offset_z, i_r, i_cur_r)] * j_2d[(i_cur_z, i_cur_r)] * d_area;
+                    }
+                }
+            }
+        }
+        field
+    }
+
+    /// Deterministic pseudo-random values in [-1, 1)
+    fn pseudo_random(seed: &mut u64) -> f64 {
+        *seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((*seed >> 11) as f64) / ((1u64 << 53) as f64) * 2.0 - 1.0
+    }
+
+    #[test]
+    fn test_smooth_even_fft_length() {
+        assert_eq!(smooth_even_fft_length(321), 324);
+        assert_eq!(smooth_even_fft_length(257), 270);
+        assert_eq!(smooth_even_fft_length(641), 648);
+        assert_eq!(smooth_even_fft_length(1), 2);
+    }
+
+    #[test]
+    fn test_convolve_matches_direct_sum() {
+        let n_r: usize = 5;
+        let n_z: usize = 7;
+        let d_area: f64 = 0.25;
+        let mut seed: u64 = 12345;
+
+        let mut even_tables: Vec<Array3<f64>> = Vec::new();
+        for _i_kernel in 0..N_EVEN_KERNELS {
+            let mut table: Array3<f64> = Array3::zeros((n_z, n_r, n_r));
+            for value in table.iter_mut() {
+                *value = pseudo_random(&mut seed);
+            }
+            even_tables.push(table);
+        }
+        let mut odd_tables: Vec<Array3<f64>> = Vec::new();
+        for _i_kernel in 0..N_ODD_KERNELS {
+            let mut table: Array3<f64> = Array3::zeros((n_z, n_r, n_r));
+            for value in table.iter_mut() {
+                *value = pseudo_random(&mut seed);
+            }
+            // Odd kernels vanish at zero vertical offset
+            for i_r in 0..n_r {
+                for i_cur_r in 0..n_r {
+                    table[(0, i_r, i_cur_r)] = 0.0;
+                }
+            }
+            odd_tables.push(table);
+        }
+        let mut j_2d: Array2<f64> = Array2::zeros((n_z, n_r));
+        for value in j_2d.iter_mut() {
+            *value = pseudo_random(&mut seed);
+        }
+        // An empty current column exercises the active-column selection
+        for i_z in 0..n_z {
+            j_2d[(i_z, 2)] = 0.0;
+        }
+
+        let even_views: Vec<ArrayView3<f64>> = even_tables.iter().map(|table| table.view()).collect();
+        let odd_views: Vec<ArrayView3<f64>> = odd_tables.iter().map(|table| table.view()).collect();
+        let spectra: PlasmaGreensSpectra = PlasmaGreensSpectra::from_tables(n_r, n_z, &even_views, &odd_views);
+        let (plasma_even, plasma_odd): (Array2<f64>, Array2<f64>) = spectra.convolve(&j_2d, d_area);
+
+        for i_kernel in 0..N_EVEN_KERNELS {
+            let expected: Array2<f64> = direct_sum(&even_tables[i_kernel], &j_2d, d_area, false);
+            for i_z in 0..n_z {
+                for i_r in 0..n_r {
+                    let difference: f64 = (plasma_even[(i_z, i_kernel * n_r + i_r)] - expected[(i_z, i_r)]).abs();
+                    assert!(difference < 1.0e-12, "even kernel {i_kernel}: difference {difference} at ({i_z}, {i_r})");
+                }
+            }
+        }
+        for i_kernel in 0..N_ODD_KERNELS {
+            let expected: Array2<f64> = direct_sum(&odd_tables[i_kernel], &j_2d, d_area, true);
+            for i_z in 0..n_z {
+                for i_r in 0..n_r {
+                    let difference: f64 = (plasma_odd[(i_z, i_kernel * n_r + i_r)] - expected[(i_z, i_r)]).abs();
+                    assert!(difference < 1.0e-12, "odd kernel {i_kernel}: difference {difference} at ({i_z}, {i_r})");
+                }
+            }
+        }
+    }
+}

--- a/rust/gsfit_rs/src/greens/greens.rs
+++ b/rust/gsfit_rs/src/greens/greens.rs
@@ -20,6 +20,24 @@ const XI: f64 = 0.157;
 /// We could replace this tolerance with one on `k_sq`, as the problem we are avoiding is that `K(k_sq) --> \infty` as `k_sq --> 1.0`, but that loses the physical meaning of "near distance".
 const SELF_POINT_DISTANCE_TOLERANCE: f64 = 1e-7; // = 0.1 μm
 
+/// Tables with at most this many sensors **and** at most this many conductors are evaluated
+/// sequentially rather than on the Rayon thread pool: for such small tables, e.g. the 100 x 100
+/// sub-filament blocks of the mutual-inductance quadrature (whose outer loop is already parallel),
+/// the task overhead exceeds the work. The results are identical either way.
+const PARALLEL_MIN_DIMENSION: usize = 256;
+
+/// Evaluate `f(i_conductor_rz)` for every conductor, in parallel for large tables and sequentially for small ones
+fn map_over_conductors<T: Send>(n_rz: usize, conductor_n_rz: usize, f: impl Fn(usize) -> T + Sync + Send) -> Vec<T> {
+    if n_rz <= PARALLEL_MIN_DIMENSION && conductor_n_rz <= PARALLEL_MIN_DIMENSION {
+        let mut results: Vec<T> = Vec::with_capacity(conductor_n_rz);
+        for i_conductor_rz in 0..conductor_n_rz {
+            results.push(f(i_conductor_rz));
+        }
+        return results;
+    }
+    return (0..conductor_n_rz).into_par_iter().map(f).collect();
+}
+
 /// Greens-function table between "sensors" `(r, z)` and "conductors" `(conductor_r, conductor_z)`.
 ///
 /// Several methods (`greens_psi`, `greens_d_psi_d_r`, ...) share the same elliptic integrals.
@@ -139,20 +157,17 @@ impl Greens {
         );
 
         // Pre-compute the elliptic integrals
-        let elliptic_integrals: Vec<(Array1<f64>, Array1<f64>)> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let r_sq: Array1<f64> = (&sensor_r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2));
-                let z_sq: Array1<f64> = (&sensor_z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+        let elliptic_integrals: Vec<(Array1<f64>, Array1<f64>)> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let r_sq: Array1<f64> = (&sensor_r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+            let z_sq: Array1<f64> = (&sensor_z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
 
-                let rr: Array1<f64> = &sensor_r * conductor_r[i_conductor_rz];
-                let k_sq: Array1<f64> = 4.0 * &rr / (r_sq + z_sq);
+            let rr: Array1<f64> = &sensor_r * conductor_r[i_conductor_rz];
+            let k_sq: Array1<f64> = 4.0 * &rr / (r_sq + z_sq);
 
-                let e: Array1<f64> = k_sq.mapv(|x: f64| ellpe(x));
-                let k: Array1<f64> = k_sq.mapv(|x: f64| ellpk(1.0 - x)); // very annoying how this is defined differently to E
-                (e, k)
-            })
-            .collect();
+            let e: Array1<f64> = k_sq.mapv(|x: f64| ellpe(x));
+            let k: Array1<f64> = k_sq.mapv(|x: f64| ellpk(1.0 - x)); // very annoying how this is defined differently to E
+            (e, k)
+        });
 
         // Convert to Array2<f64>, with shape = (n_rz, conductor_n_rz)
         let mut elliptic_integral_e: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
@@ -209,20 +224,17 @@ impl Greens {
         );
 
         // Pre-compute the elliptic integrals
-        let elliptic_integrals: Vec<(Array1<f64>, Array1<f64>)> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let r_sq: Array1<f64> = (&sensor_r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2));
-                let z_sq: Array1<f64> = (&sensor_z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+        let elliptic_integrals: Vec<(Array1<f64>, Array1<f64>)> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let r_sq: Array1<f64> = (&sensor_r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+            let z_sq: Array1<f64> = (&sensor_z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
 
-                let rr: Array1<f64> = &sensor_r * conductor_r[i_conductor_rz];
-                let k_sq: Array1<f64> = 4.0 * &rr / (r_sq + z_sq);
+            let rr: Array1<f64> = &sensor_r * conductor_r[i_conductor_rz];
+            let k_sq: Array1<f64> = 4.0 * &rr / (r_sq + z_sq);
 
-                let e: Array1<f64> = k_sq.mapv(|x: f64| ellpe(x));
-                let k: Array1<f64> = k_sq.mapv(|x: f64| ellpk(1.0 - x)); // very annoying how this is defined differently to E
-                (e, k)
-            })
-            .collect();
+            let e: Array1<f64> = k_sq.mapv(|x: f64| ellpe(x));
+            let k: Array1<f64> = k_sq.mapv(|x: f64| ellpk(1.0 - x)); // very annoying how this is defined differently to E
+            (e, k)
+        });
 
         // Convert to Array2<f64>, with shape = (n_rz, conductor_n_rz)
         let mut elliptic_integral_e: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
@@ -280,57 +292,53 @@ impl Greens {
         let elliptic_integral_k: ArrayView2<f64> = self.elliptic_integral_k.view();
         let elliptic_integral_e: ArrayView2<f64> = self.elliptic_integral_e.view();
 
-        let results: Vec<Array1<f64>> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let r_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2));
-                let z_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+        let results: Vec<Array1<f64>> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let r_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+            let z_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
 
-                let rr: Array1<f64> = r * conductor_r[i_conductor_rz];
-                let k_sq: Array1<f64> = 4.0 * &rr / (&r_sq + &z_sq);
-                let u: Array1<f64> = (&r_sq + &z_sq).mapv(|x: f64| x.sqrt());
+            let rr: Array1<f64> = r * conductor_r[i_conductor_rz];
+            let k_sq: Array1<f64> = 4.0 * &rr / (&r_sq + &z_sq);
+            let u: Array1<f64> = (&r_sq + &z_sq).mapv(|x: f64| x.sqrt());
 
-                let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
-                let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
 
-                // g_psi = coeff_a * (K - E) + coeff_s * E
-                // coeff_a = MU_0 * sqrt(r * conductor_r) * (2 - k_sq) / k
-                // coeff_s = -2 * MU_0 * r * conductor_r / u
-                let mut green_this_filament = Array1::<f64>::zeros(n_rz);
-                for i_rz in 0..n_rz {
-                    let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
+            // g_psi = coeff_a * (K - E) + coeff_s * E
+            // coeff_a = MU_0 * sqrt(r * conductor_r) * (2 - k_sq) / k
+            // coeff_s = -2 * MU_0 * r * conductor_r / u
+            let mut green_this_filament = Array1::<f64>::zeros(n_rz);
+            for i_rz in 0..n_rz {
+                let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
 
-                    let coeff_a: f64 = MU_0 * rr[i_rz].sqrt() * (2.0 - k_sq[i_rz]) / k_sq[i_rz].sqrt();
-                    let coeff_s: f64 = -2.0 * MU_0 * rr[i_rz] / u[i_rz];
+                let coeff_a: f64 = MU_0 * rr[i_rz].sqrt() * (2.0 - k_sq[i_rz]) / k_sq[i_rz].sqrt();
+                let coeff_s: f64 = -2.0 * MU_0 * rr[i_rz] / u[i_rz];
 
-                    green_this_filament[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+                green_this_filament[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+            }
+
+            // Test for checking if conductor and sensor are at same location
+            // this is for grid-grid calculation
+            // If we do this earlier we can skip calculating elliptic integrals.
+            // But this would be quite complicated as we do the elliptic integrals in initialisation.
+            //
+            // Self-point: the flux at the centre of the cell from its own uniform current
+            // psi = MU_0 * r * (ln(8 * r) - 2 - p_c)
+            // where `p_c` is the mean log distance from the cell centre to the cross-section:
+            // p_c = 0.5 * ln((d_r^2 + d_z^2) / 4) - 3/2 + (d_r / (2 * d_z)) * atan(d_z / d_r) + (d_z / (2 * d_r)) * atan(d_r / d_z)
+            for i_rz in 0..n_rz {
+                if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                    && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                {
+                    let d_r: f64 = conductor_d_r[i_conductor_rz];
+                    let d_z: f64 = conductor_d_z[i_conductor_rz];
+                    let p_c: f64 =
+                        0.5 * ((d_r.powi(2) + d_z.powi(2)) / 4.0).ln() - 1.5 + d_r / (2.0 * d_z) * (d_z / d_r).atan() + d_z / (2.0 * d_r) * (d_r / d_z).atan();
+                    green_this_filament[i_rz] = MU_0 * r[i_rz] * ((8.0 * r[i_rz]).ln() - 2.0 - p_c);
                 }
+            }
 
-                // Test for checking if conductor and sensor are at same location
-                // this is for grid-grid calculation
-                // If we do this earlier we can skip calculating elliptic integrals.
-                // But this would be quite complicated as we do the elliptic integrals in initialisation.
-                //
-                // Self-point: the flux at the centre of the cell from its own uniform current
-                // psi = MU_0 * r * (ln(8 * r) - 2 - p_c)
-                // where `p_c` is the mean log distance from the cell centre to the cross-section:
-                // p_c = 0.5 * ln((d_r^2 + d_z^2) / 4) - 3/2 + (d_r / (2 * d_z)) * atan(d_z / d_r) + (d_z / (2 * d_r)) * atan(d_r / d_z)
-                for i_rz in 0..n_rz {
-                    if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                        && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                    {
-                        let d_r: f64 = conductor_d_r[i_conductor_rz];
-                        let d_z: f64 = conductor_d_z[i_conductor_rz];
-                        let p_c: f64 = 0.5 * ((d_r.powi(2) + d_z.powi(2)) / 4.0).ln() - 1.5
-                            + d_r / (2.0 * d_z) * (d_z / d_r).atan()
-                            + d_z / (2.0 * d_r) * (d_r / d_z).atan();
-                        green_this_filament[i_rz] = MU_0 * r[i_rz] * ((8.0 * r[i_rz]).ln() - 2.0 - p_c);
-                    }
-                }
-
-                return green_this_filament;
-            })
-            .collect();
+            return green_this_filament;
+        });
 
         let mut g_psi: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
         for i_conductor_rz in 0..conductor_n_rz {
@@ -378,45 +386,42 @@ impl Greens {
         let elliptic_integral_k: ArrayView2<f64> = self.elliptic_integral_k.view();
         let elliptic_integral_e: ArrayView2<f64> = self.elliptic_integral_e.view();
 
-        let g_d_psi_d_r_vec: Vec<Array1<f64>> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let h_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
-                let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
-                let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+        let g_d_psi_d_r_vec: Vec<Array1<f64>> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let h_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+            let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
+            let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
 
-                let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
-                let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
 
-                // g_d_psi_d_r = coeff_a * (K - E) + coeff_s * E
-                let mut g_d_psi_d_r_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
-                for i_rz in 0..n_rz {
-                    let rp: f64 = conductor_r[i_conductor_rz];
-                    let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
+            // g_d_psi_d_r = coeff_a * (K - E) + coeff_s * E
+            let mut g_d_psi_d_r_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
+            for i_rz in 0..n_rz {
+                let rp: f64 = conductor_r[i_conductor_rz];
+                let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
 
-                    let coeff_a: f64 = MU_0 * r[i_rz] / u[i_rz];
-                    let coeff_s: f64 = -2.0 * MU_0 * r[i_rz] * rp * (r[i_rz] - rp) / (u[i_rz] * d_sq[i_rz]);
+                let coeff_a: f64 = MU_0 * r[i_rz] / u[i_rz];
+                let coeff_s: f64 = -2.0 * MU_0 * r[i_rz] * rp * (r[i_rz] - rp) / (u[i_rz] * d_sq[i_rz]);
 
-                    g_d_psi_d_r_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+                g_d_psi_d_r_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+            }
+
+            // Self-point: the hoop field of the finite rectangular cross-section
+            // <d_psi_d_r> = (MU_0 / 2) * (ln(16 * r / sqrt(d_r^2 + d_z^2)) + 1 - (d_z / d_r) * atan(d_r / d_z))
+            for i_rz in 0..n_rz {
+                if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                    && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                {
+                    let d_r: f64 = conductor_d_r[i_conductor_rz];
+                    let d_z: f64 = conductor_d_z[i_conductor_rz];
+                    g_d_psi_d_r_local[i_rz] =
+                        MU_0 / 2.0 * ((16.0 * r[i_rz] / (d_r.powi(2) + d_z.powi(2)).sqrt()).ln() + 1.0 - (d_z / d_r) * (d_r / d_z).atan());
                 }
+            }
 
-                // Self-point: the hoop field of the finite rectangular cross-section
-                // <d_psi_d_r> = (MU_0 / 2) * (ln(16 * r / sqrt(d_r^2 + d_z^2)) + 1 - (d_z / d_r) * atan(d_r / d_z))
-                for i_rz in 0..n_rz {
-                    if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                        && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                    {
-                        let d_r: f64 = conductor_d_r[i_conductor_rz];
-                        let d_z: f64 = conductor_d_z[i_conductor_rz];
-                        g_d_psi_d_r_local[i_rz] =
-                            MU_0 / 2.0 * ((16.0 * r[i_rz] / (d_r.powi(2) + d_z.powi(2)).sqrt()).ln() + 1.0 - (d_z / d_r) * (d_r / d_z).atan());
-                    }
-                }
-
-                g_d_psi_d_r_local
-            })
-            .collect();
+            g_d_psi_d_r_local
+        });
 
         let mut g_d_psi_d_r: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
         for i_conductor_rz in 0..conductor_n_rz {
@@ -447,45 +452,42 @@ impl Greens {
         let elliptic_integral_k: ArrayView2<f64> = self.elliptic_integral_k.view();
         let elliptic_integral_e: ArrayView2<f64> = self.elliptic_integral_e.view();
 
-        let g_d_psi_d_z_vec: Vec<Array1<f64>> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let h: Array1<f64> = z - conductor_z[i_conductor_rz];
-                let h_sq: Array1<f64> = h.mapv(|x: f64| x.powi(2));
-                let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
-                let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+        let g_d_psi_d_z_vec: Vec<Array1<f64>> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let h: Array1<f64> = z - conductor_z[i_conductor_rz];
+            let h_sq: Array1<f64> = h.mapv(|x: f64| x.powi(2));
+            let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
+            let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
 
-                let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
-                let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
 
-                // g_d_psi_d_z = coeff_a * (K - E) + coeff_s * E
-                // coeff_a = MU_0 * h / u
-                // coeff_s = -2 * MU_0 * r * conductor_r * h / (u * d_sq)
-                let mut g_d_psi_d_z_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
-                for i_rz in 0..n_rz {
-                    let rp: f64 = conductor_r[i_conductor_rz];
-                    let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
+            // g_d_psi_d_z = coeff_a * (K - E) + coeff_s * E
+            // coeff_a = MU_0 * h / u
+            // coeff_s = -2 * MU_0 * r * conductor_r * h / (u * d_sq)
+            let mut g_d_psi_d_z_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
+            for i_rz in 0..n_rz {
+                let rp: f64 = conductor_r[i_conductor_rz];
+                let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
 
-                    let coeff_a: f64 = MU_0 * h[i_rz] / u[i_rz];
-                    let coeff_s: f64 = -2.0 * MU_0 * r[i_rz] * rp * h[i_rz] / (u[i_rz] * d_sq[i_rz]);
+                let coeff_a: f64 = MU_0 * h[i_rz] / u[i_rz];
+                let coeff_s: f64 = -2.0 * MU_0 * r[i_rz] * rp * h[i_rz] / (u[i_rz] * d_sq[i_rz]);
 
-                    g_d_psi_d_z_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+                g_d_psi_d_z_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+            }
+
+            // Self-point: the kernel is odd in h, so the value is EXACTLY zero for any
+            // z-symmetric cross-section
+            for i_rz in 0..n_rz {
+                if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                    && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                {
+                    g_d_psi_d_z_local[i_rz] = 0.0;
                 }
+            }
 
-                // Self-point: the kernel is odd in h, so the value is EXACTLY zero for any
-                // z-symmetric cross-section
-                for i_rz in 0..n_rz {
-                    if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                        && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                    {
-                        g_d_psi_d_z_local[i_rz] = 0.0;
-                    }
-                }
-
-                g_d_psi_d_z_local
-            })
-            .collect();
+            g_d_psi_d_z_local
+        });
 
         let mut g_d_psi_d_z: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
         for i_conductor_rz in 0..conductor_n_rz {
@@ -526,52 +528,49 @@ impl Greens {
         let elliptic_integral_k: ArrayView2<f64> = self.elliptic_integral_k.view();
         let elliptic_integral_e: ArrayView2<f64> = self.elliptic_integral_e.view();
 
-        let g_d2_psi_d_r2_vec: Vec<Array1<f64>> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let h_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
-                let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
-                let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+        let g_d2_psi_d_r2_vec: Vec<Array1<f64>> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let h_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+            let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
+            let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
 
-                let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
-                let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
 
-                // g_d2_psi_d_r2 = coeff_a * (K - E) + coeff_s * E
-                // coeff_a = MU_0 * (u_sq + d_sq) * h_sq / (2 * u^3 * d_sq)
-                // coeff_s = 2 * MU_0 * conductor_r * (conductor_r * u_sq * d_sq - r * (2 * u_sq - d_sq) * h_sq) / (u^3 * d_sq^2)
-                let mut g_d2_psi_d_r2_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
-                for i_rz in 0..n_rz {
-                    let rp: f64 = conductor_r[i_conductor_rz];
-                    let us: f64 = u_sq[i_rz];
-                    let ds: f64 = d_sq[i_rz];
-                    let hs: f64 = h_sq[i_rz];
-                    let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
+            // g_d2_psi_d_r2 = coeff_a * (K - E) + coeff_s * E
+            // coeff_a = MU_0 * (u_sq + d_sq) * h_sq / (2 * u^3 * d_sq)
+            // coeff_s = 2 * MU_0 * conductor_r * (conductor_r * u_sq * d_sq - r * (2 * u_sq - d_sq) * h_sq) / (u^3 * d_sq^2)
+            let mut g_d2_psi_d_r2_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
+            for i_rz in 0..n_rz {
+                let rp: f64 = conductor_r[i_conductor_rz];
+                let us: f64 = u_sq[i_rz];
+                let ds: f64 = d_sq[i_rz];
+                let hs: f64 = h_sq[i_rz];
+                let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
 
-                    let coeff_a: f64 = MU_0 * (us + ds) * hs / (2.0 * u[i_rz] * us * ds);
-                    let coeff_s: f64 = 2.0 * MU_0 * rp * (rp * us * ds - r[i_rz] * (2.0 * us - ds) * hs) / (u[i_rz] * us * ds * ds);
+                let coeff_a: f64 = MU_0 * (us + ds) * hs / (2.0 * u[i_rz] * us * ds);
+                let coeff_s: f64 = 2.0 * MU_0 * rp * (rp * us * ds - r[i_rz] * (2.0 * us - ds) * hs) / (u[i_rz] * us * ds * ds);
 
-                    g_d2_psi_d_r2_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+                g_d2_psi_d_r2_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+            }
+
+            // Self-point: dominated by the cell's own interior field, plus a share of the
+            // hoop-field correction `d_psi_d_r / r` (split by XI) so that Ampere's law is satisfied
+            // <d2_psi_d_r2> = -4 * MU_0 * r * atan(d_z / d_r) / (d_r * d_z) + (1/2 - XI) * <d_psi_d_r> / r
+            for i_rz in 0..n_rz {
+                if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                    && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                {
+                    let d_r: f64 = conductor_d_r[i_conductor_rz];
+                    let d_z: f64 = conductor_d_z[i_conductor_rz];
+                    let d_psi_d_r_self: f64 =
+                        MU_0 / 2.0 * ((16.0 * r[i_rz] / (d_r.powi(2) + d_z.powi(2)).sqrt()).ln() + 1.0 - (d_z / d_r) * (d_r / d_z).atan());
+                    g_d2_psi_d_r2_local[i_rz] = -4.0 * MU_0 * r[i_rz] * (d_z / d_r).atan() / (d_r * d_z) + (0.5 - XI) * d_psi_d_r_self / r[i_rz];
                 }
+            }
 
-                // Self-point: dominated by the cell's own interior field, plus a share of the
-                // hoop-field correction `d_psi_d_r / r` (split by XI) so that Ampere's law is satisfied
-                // <d2_psi_d_r2> = -4 * MU_0 * r * atan(d_z / d_r) / (d_r * d_z) + (1/2 - XI) * <d_psi_d_r> / r
-                for i_rz in 0..n_rz {
-                    if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                        && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                    {
-                        let d_r: f64 = conductor_d_r[i_conductor_rz];
-                        let d_z: f64 = conductor_d_z[i_conductor_rz];
-                        let d_psi_d_r_self: f64 =
-                            MU_0 / 2.0 * ((16.0 * r[i_rz] / (d_r.powi(2) + d_z.powi(2)).sqrt()).ln() + 1.0 - (d_z / d_r) * (d_r / d_z).atan());
-                        g_d2_psi_d_r2_local[i_rz] = -4.0 * MU_0 * r[i_rz] * (d_z / d_r).atan() / (d_r * d_z) + (0.5 - XI) * d_psi_d_r_self / r[i_rz];
-                    }
-                }
-
-                g_d2_psi_d_r2_local
-            })
-            .collect();
+            g_d2_psi_d_r2_local
+        });
 
         let mut g_d2_psi_d_r2: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
         for i_conductor_rz in 0..conductor_n_rz {
@@ -602,48 +601,45 @@ impl Greens {
         let elliptic_integral_k: ArrayView2<f64> = self.elliptic_integral_k.view();
         let elliptic_integral_e: ArrayView2<f64> = self.elliptic_integral_e.view();
 
-        let g_d2_psi_d_r_d_z_vec: Vec<Array1<f64>> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let h: Array1<f64> = z - conductor_z[i_conductor_rz];
-                let h_sq: Array1<f64> = h.mapv(|x: f64| x.powi(2));
-                let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
-                let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let w_sq: Array1<f64> = r.mapv(|x: f64| conductor_r[i_conductor_rz].powi(2) - x.powi(2)) - &h_sq;
+        let g_d2_psi_d_r_d_z_vec: Vec<Array1<f64>> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let h: Array1<f64> = z - conductor_z[i_conductor_rz];
+            let h_sq: Array1<f64> = h.mapv(|x: f64| x.powi(2));
+            let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
+            let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let w_sq: Array1<f64> = r.mapv(|x: f64| conductor_r[i_conductor_rz].powi(2) - x.powi(2)) - &h_sq;
 
-                let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
-                let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
 
-                // g_d2_psi_d_r_d_z = coeff_a * (K - E) + coeff_s * E
-                // coeff_a = MU_0 * r * h * w_sq / (u^3 * d_sq)
-                // coeff_s = 2 * MU_0 * r * conductor_r * h * (2 * u_sq * (r - conductor_r) - (r + conductor_r) * d_sq) / (u^3 * d_sq^2)
-                let mut g_d2_psi_d_r_d_z_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
-                for i_rz in 0..n_rz {
-                    let rp: f64 = conductor_r[i_conductor_rz];
-                    let us: f64 = u_sq[i_rz];
-                    let ds: f64 = d_sq[i_rz];
-                    let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
+            // g_d2_psi_d_r_d_z = coeff_a * (K - E) + coeff_s * E
+            // coeff_a = MU_0 * r * h * w_sq / (u^3 * d_sq)
+            // coeff_s = 2 * MU_0 * r * conductor_r * h * (2 * u_sq * (r - conductor_r) - (r + conductor_r) * d_sq) / (u^3 * d_sq^2)
+            let mut g_d2_psi_d_r_d_z_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
+            for i_rz in 0..n_rz {
+                let rp: f64 = conductor_r[i_conductor_rz];
+                let us: f64 = u_sq[i_rz];
+                let ds: f64 = d_sq[i_rz];
+                let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
 
-                    let coeff_a: f64 = MU_0 * r[i_rz] * h[i_rz] * w_sq[i_rz] / (u[i_rz] * us * ds);
-                    let coeff_s: f64 = 2.0 * MU_0 * r[i_rz] * rp * h[i_rz] * (2.0 * us * (r[i_rz] - rp) - (r[i_rz] + rp) * ds) / (u[i_rz] * us * ds * ds);
+                let coeff_a: f64 = MU_0 * r[i_rz] * h[i_rz] * w_sq[i_rz] / (u[i_rz] * us * ds);
+                let coeff_s: f64 = 2.0 * MU_0 * r[i_rz] * rp * h[i_rz] * (2.0 * us * (r[i_rz] - rp) - (r[i_rz] + rp) * ds) / (u[i_rz] * us * ds * ds);
 
-                    g_d2_psi_d_r_d_z_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+                g_d2_psi_d_r_d_z_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+            }
+
+            // Self-point: the kernel is odd in h, so the value is EXACTLY zero for any
+            // z-symmetric cross-section
+            for i_rz in 0..n_rz {
+                if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                    && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                {
+                    g_d2_psi_d_r_d_z_local[i_rz] = 0.0;
                 }
+            }
 
-                // Self-point: the kernel is odd in h, so the value is EXACTLY zero for any
-                // z-symmetric cross-section
-                for i_rz in 0..n_rz {
-                    if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                        && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                    {
-                        g_d2_psi_d_r_d_z_local[i_rz] = 0.0;
-                    }
-                }
-
-                g_d2_psi_d_r_d_z_local
-            })
-            .collect();
+            g_d2_psi_d_r_d_z_local
+        });
 
         let mut g_d2_psi_d_r_d_z: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
         for i_conductor_rz in 0..conductor_n_rz {
@@ -681,52 +677,49 @@ impl Greens {
         let elliptic_integral_k: ArrayView2<f64> = self.elliptic_integral_k.view();
         let elliptic_integral_e: ArrayView2<f64> = self.elliptic_integral_e.view();
 
-        let g_d2_psi_d_z2_vec: Vec<Array1<f64>> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let h_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
-                let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
-                let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+        let g_d2_psi_d_z2_vec: Vec<Array1<f64>> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let h_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+            let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
+            let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
 
-                let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
-                let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
 
-                // g_d2_psi_d_z2 = coeff_a * (K - E) + coeff_s * E
-                // coeff_a = MU_0 * (2 * u_sq * d_sq - (u_sq + d_sq) * h_sq) / (2 * u^3 * d_sq)
-                // coeff_s = -2 * MU_0 * r * conductor_r * (u_sq * d_sq - (2 * u_sq - d_sq) * h_sq) / (u^3 * d_sq^2)
-                let mut g_d2_psi_d_z2_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
-                for i_rz in 0..n_rz {
-                    let rp: f64 = conductor_r[i_conductor_rz];
-                    let us: f64 = u_sq[i_rz];
-                    let ds: f64 = d_sq[i_rz];
-                    let hs: f64 = h_sq[i_rz];
-                    let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
+            // g_d2_psi_d_z2 = coeff_a * (K - E) + coeff_s * E
+            // coeff_a = MU_0 * (2 * u_sq * d_sq - (u_sq + d_sq) * h_sq) / (2 * u^3 * d_sq)
+            // coeff_s = -2 * MU_0 * r * conductor_r * (u_sq * d_sq - (2 * u_sq - d_sq) * h_sq) / (u^3 * d_sq^2)
+            let mut g_d2_psi_d_z2_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
+            for i_rz in 0..n_rz {
+                let rp: f64 = conductor_r[i_conductor_rz];
+                let us: f64 = u_sq[i_rz];
+                let ds: f64 = d_sq[i_rz];
+                let hs: f64 = h_sq[i_rz];
+                let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
 
-                    let coeff_a: f64 = MU_0 * (2.0 * us * ds - (us + ds) * hs) / (2.0 * u[i_rz] * us * ds);
-                    let coeff_s: f64 = -2.0 * MU_0 * r[i_rz] * rp * (us * ds - (2.0 * us - ds) * hs) / (u[i_rz] * us * ds * ds);
+                let coeff_a: f64 = MU_0 * (2.0 * us * ds - (us + ds) * hs) / (2.0 * u[i_rz] * us * ds);
+                let coeff_s: f64 = -2.0 * MU_0 * r[i_rz] * rp * (us * ds - (2.0 * us - ds) * hs) / (u[i_rz] * us * ds * ds);
 
-                    g_d2_psi_d_z2_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+                g_d2_psi_d_z2_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+            }
+
+            // Self-point: dominated by the cell's own interior field, plus a share of the
+            // hoop-field correction `d_psi_d_r / r` (split by XI) so that Ampere's law is satisfied
+            // <d2_psi_d_z2> = -4 * MU_0 * r * atan(d_r / d_z) / (d_r * d_z) + (1/2 + XI) * <d_psi_d_r> / r
+            for i_rz in 0..n_rz {
+                if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                    && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                {
+                    let d_r: f64 = conductor_d_r[i_conductor_rz];
+                    let d_z: f64 = conductor_d_z[i_conductor_rz];
+                    let d_psi_d_r_self: f64 =
+                        MU_0 / 2.0 * ((16.0 * r[i_rz] / (d_r.powi(2) + d_z.powi(2)).sqrt()).ln() + 1.0 - (d_z / d_r) * (d_r / d_z).atan());
+                    g_d2_psi_d_z2_local[i_rz] = -4.0 * MU_0 * r[i_rz] * (d_r / d_z).atan() / (d_r * d_z) + (0.5 + XI) * d_psi_d_r_self / r[i_rz];
                 }
+            }
 
-                // Self-point: dominated by the cell's own interior field, plus a share of the
-                // hoop-field correction `d_psi_d_r / r` (split by XI) so that Ampere's law is satisfied
-                // <d2_psi_d_z2> = -4 * MU_0 * r * atan(d_r / d_z) / (d_r * d_z) + (1/2 + XI) * <d_psi_d_r> / r
-                for i_rz in 0..n_rz {
-                    if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                        && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                    {
-                        let d_r: f64 = conductor_d_r[i_conductor_rz];
-                        let d_z: f64 = conductor_d_z[i_conductor_rz];
-                        let d_psi_d_r_self: f64 =
-                            MU_0 / 2.0 * ((16.0 * r[i_rz] / (d_r.powi(2) + d_z.powi(2)).sqrt()).ln() + 1.0 - (d_z / d_r) * (d_r / d_z).atan());
-                        g_d2_psi_d_z2_local[i_rz] = -4.0 * MU_0 * r[i_rz] * (d_r / d_z).atan() / (d_r * d_z) + (0.5 + XI) * d_psi_d_r_self / r[i_rz];
-                    }
-                }
-
-                g_d2_psi_d_z2_local
-            })
-            .collect();
+            g_d2_psi_d_z2_local
+        });
 
         let mut g_d2_psi_d_z2: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
         for i_conductor_rz in 0..conductor_n_rz {
@@ -757,50 +750,47 @@ impl Greens {
         let elliptic_integral_k: ArrayView2<f64> = self.elliptic_integral_k.view();
         let elliptic_integral_e: ArrayView2<f64> = self.elliptic_integral_e.view();
 
-        let g_d3_psi_d_z3_vec: Vec<Array1<f64>> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let h: Array1<f64> = z - conductor_z[i_conductor_rz];
-                let h_sq: Array1<f64> = h.mapv(|x: f64| x.powi(2));
-                let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
-                let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+        let g_d3_psi_d_z3_vec: Vec<Array1<f64>> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let h: Array1<f64> = z - conductor_z[i_conductor_rz];
+            let h_sq: Array1<f64> = h.mapv(|x: f64| x.powi(2));
+            let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
+            let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
 
-                let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
-                let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
 
-                // g_d3_psi_d_z3 = coeff_a * (K - E) + coeff_s * E
-                // coeff_a = -MU_0 * h * (u_sq * d_sq * (3 * (u_sq + d_sq) + 10 * h_sq) - 4 * (u_sq + d_sq)^2 * h_sq) / (2 * u^5 * d_sq^2)
-                // coeff_s = 2 * MU_0 * r * conductor_r * h * (3 * u_sq * d_sq * (2 * u_sq - d_sq) - (8 * u_sq^2 - u_sq * d_sq - 4 * d_sq^2) * h_sq) / (u^5 * d_sq^3)
-                let mut g_d3_psi_d_z3_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
-                for i_rz in 0..n_rz {
-                    let rp: f64 = conductor_r[i_conductor_rz];
-                    let us: f64 = u_sq[i_rz];
-                    let ds: f64 = d_sq[i_rz];
-                    let hs: f64 = h_sq[i_rz];
-                    let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
+            // g_d3_psi_d_z3 = coeff_a * (K - E) + coeff_s * E
+            // coeff_a = -MU_0 * h * (u_sq * d_sq * (3 * (u_sq + d_sq) + 10 * h_sq) - 4 * (u_sq + d_sq)^2 * h_sq) / (2 * u^5 * d_sq^2)
+            // coeff_s = 2 * MU_0 * r * conductor_r * h * (3 * u_sq * d_sq * (2 * u_sq - d_sq) - (8 * u_sq^2 - u_sq * d_sq - 4 * d_sq^2) * h_sq) / (u^5 * d_sq^3)
+            let mut g_d3_psi_d_z3_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
+            for i_rz in 0..n_rz {
+                let rp: f64 = conductor_r[i_conductor_rz];
+                let us: f64 = u_sq[i_rz];
+                let ds: f64 = d_sq[i_rz];
+                let hs: f64 = h_sq[i_rz];
+                let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
 
-                    let coeff_a: f64 =
-                        -MU_0 * h[i_rz] * (us * ds * (3.0 * (us + ds) + 10.0 * hs) - 4.0 * (us + ds) * (us + ds) * hs) / (2.0 * u[i_rz] * us * us * ds * ds);
-                    let coeff_s: f64 = 2.0 * MU_0 * r[i_rz] * rp * h[i_rz] * (3.0 * us * ds * (2.0 * us - ds) - (8.0 * us * us - us * ds - 4.0 * ds * ds) * hs)
-                        / (u[i_rz] * us * us * ds * ds * ds);
+                let coeff_a: f64 =
+                    -MU_0 * h[i_rz] * (us * ds * (3.0 * (us + ds) + 10.0 * hs) - 4.0 * (us + ds) * (us + ds) * hs) / (2.0 * u[i_rz] * us * us * ds * ds);
+                let coeff_s: f64 = 2.0 * MU_0 * r[i_rz] * rp * h[i_rz] * (3.0 * us * ds * (2.0 * us - ds) - (8.0 * us * us - us * ds - 4.0 * ds * ds) * hs)
+                    / (u[i_rz] * us * us * ds * ds * ds);
 
-                    g_d3_psi_d_z3_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+                g_d3_psi_d_z3_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+            }
+
+            // Set to zero when conductor and sensor are at the same location
+            // (d3_psi_d_z3 is odd in h, so zero is the symmetric value at the self-point)
+            for i_rz in 0..n_rz {
+                if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                    && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                {
+                    g_d3_psi_d_z3_local[i_rz] = 0.0;
                 }
+            }
 
-                // Set to zero when conductor and sensor are at the same location
-                // (d3_psi_d_z3 is odd in h, so zero is the symmetric value at the self-point)
-                for i_rz in 0..n_rz {
-                    if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                        && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                    {
-                        g_d3_psi_d_z3_local[i_rz] = 0.0;
-                    }
-                }
-
-                g_d3_psi_d_z3_local
-            })
-            .collect();
+            g_d3_psi_d_z3_local
+        });
 
         let mut g_d3_psi_d_z3: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
         for i_conductor_rz in 0..conductor_n_rz {
@@ -868,61 +858,58 @@ impl Greens {
         let elliptic_integral_k: ArrayView2<f64> = self.elliptic_integral_k.view();
         let elliptic_integral_e: ArrayView2<f64> = self.elliptic_integral_e.view();
 
-        let g_d3_psi_d_r_d_z2_vec: Vec<Array1<f64>> = (0..conductor_n_rz)
-            .into_par_iter()
-            .map(|i_conductor_rz: usize| {
-                let h_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
-                let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
-                let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
-                let w_sq: Array1<f64> = r.mapv(|x: f64| conductor_r[i_conductor_rz].powi(2) - x.powi(2)) - &h_sq;
+        let g_d3_psi_d_r_d_z2_vec: Vec<Array1<f64>> = map_over_conductors(n_rz, conductor_n_rz, |i_conductor_rz: usize| {
+            let h_sq: Array1<f64> = (z - conductor_z[i_conductor_rz]).mapv(|x: f64| x.powi(2));
+            let u_sq: Array1<f64> = (r + conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let u: Array1<f64> = u_sq.mapv(|x: f64| x.sqrt());
+            let d_sq: Array1<f64> = (r - conductor_r[i_conductor_rz]).mapv(|x: f64| x.powi(2)) + &h_sq;
+            let w_sq: Array1<f64> = r.mapv(|x: f64| conductor_r[i_conductor_rz].powi(2) - x.powi(2)) - &h_sq;
 
-                let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
-                let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_k_local: ArrayView1<f64> = elliptic_integral_k.slice(s![.., i_conductor_rz]);
+            let elliptic_integral_e_local: ArrayView1<f64> = elliptic_integral_e.slice(s![.., i_conductor_rz]);
 
-                // g_d3_psi_d_r_d_z2 = coeff_a * (K - E) + coeff_s * E
-                // coeff_a = MU_0 * r * (u_sq * d_sq * w_sq - (5 * u_sq * d_sq + 4 * (u_sq + d_sq) * w_sq) * h_sq) / (u^5 * d_sq^2)
-                // coeff_s = MU_0 * r * conductor_r * (conductor_r * (8 * u_sq^3 - 3 * u_sq^2 * d_sq + 4 * d_sq^3)
-                //     - r * (8 * u_sq^3 - 3 * u_sq^2 * d_sq - 4 * d_sq^3)
-                //     - r * (8 * u_sq^2 - u_sq * d_sq - 4 * d_sq^2) * (w_sq + 2 * h_sq)
-                //     - conductor_r * (8 * u_sq^2 + 3 * u_sq * d_sq + 4 * d_sq^2) * w_sq) / (u^5 * d_sq^3)
-                let mut g_d3_psi_d_r_d_z2_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
-                for i_rz in 0..n_rz {
-                    let rp: f64 = conductor_r[i_conductor_rz];
-                    let us: f64 = u_sq[i_rz];
-                    let ds: f64 = d_sq[i_rz];
-                    let hs: f64 = h_sq[i_rz];
-                    let ws: f64 = w_sq[i_rz];
-                    let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
+            // g_d3_psi_d_r_d_z2 = coeff_a * (K - E) + coeff_s * E
+            // coeff_a = MU_0 * r * (u_sq * d_sq * w_sq - (5 * u_sq * d_sq + 4 * (u_sq + d_sq) * w_sq) * h_sq) / (u^5 * d_sq^2)
+            // coeff_s = MU_0 * r * conductor_r * (conductor_r * (8 * u_sq^3 - 3 * u_sq^2 * d_sq + 4 * d_sq^3)
+            //     - r * (8 * u_sq^3 - 3 * u_sq^2 * d_sq - 4 * d_sq^3)
+            //     - r * (8 * u_sq^2 - u_sq * d_sq - 4 * d_sq^2) * (w_sq + 2 * h_sq)
+            //     - conductor_r * (8 * u_sq^2 + 3 * u_sq * d_sq + 4 * d_sq^2) * w_sq) / (u^5 * d_sq^3)
+            let mut g_d3_psi_d_r_d_z2_local: Array1<f64> = Array1::from_elem(n_rz, f64::NAN);
+            for i_rz in 0..n_rz {
+                let rp: f64 = conductor_r[i_conductor_rz];
+                let us: f64 = u_sq[i_rz];
+                let ds: f64 = d_sq[i_rz];
+                let hs: f64 = h_sq[i_rz];
+                let ws: f64 = w_sq[i_rz];
+                let k_minus_e: f64 = elliptic_integral_k_local[i_rz] - elliptic_integral_e_local[i_rz];
 
-                    let coeff_a: f64 = MU_0 * r[i_rz] * (us * ds * ws - (5.0 * us * ds + 4.0 * (us + ds) * ws) * hs) / (u[i_rz] * us * us * ds * ds);
-                    let coeff_s: f64 = MU_0
-                        * r[i_rz]
-                        * rp
-                        * (rp * (8.0 * us * us * us - 3.0 * us * us * ds + 4.0 * ds * ds * ds)
-                            - r[i_rz] * (8.0 * us * us * us - 3.0 * us * us * ds - 4.0 * ds * ds * ds)
-                            - r[i_rz] * (8.0 * us * us - us * ds - 4.0 * ds * ds) * (ws + 2.0 * hs)
-                            - rp * (8.0 * us * us + 3.0 * us * ds + 4.0 * ds * ds) * ws)
-                        / (u[i_rz] * us * us * ds * ds * ds);
+                let coeff_a: f64 = MU_0 * r[i_rz] * (us * ds * ws - (5.0 * us * ds + 4.0 * (us + ds) * ws) * hs) / (u[i_rz] * us * us * ds * ds);
+                let coeff_s: f64 = MU_0
+                    * r[i_rz]
+                    * rp
+                    * (rp * (8.0 * us * us * us - 3.0 * us * us * ds + 4.0 * ds * ds * ds)
+                        - r[i_rz] * (8.0 * us * us * us - 3.0 * us * us * ds - 4.0 * ds * ds * ds)
+                        - r[i_rz] * (8.0 * us * us - us * ds - 4.0 * ds * ds) * (ws + 2.0 * hs)
+                        - rp * (8.0 * us * us + 3.0 * us * ds + 4.0 * ds * ds) * ws)
+                    / (u[i_rz] * us * us * ds * ds * ds);
 
-                    g_d3_psi_d_r_d_z2_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+                g_d3_psi_d_r_d_z2_local[i_rz] = coeff_a * k_minus_e + coeff_s * elliptic_integral_e_local[i_rz];
+            }
+
+            // Self-point: pure toroidal-curvature (hoop) effect
+            // <d3_psi_d_r_d_z2> = -MU_0 * (4 * atan(d_r / d_z) - 2 * d_r * d_z / (d_r^2 + d_z^2)) / (d_r * d_z)
+            for i_rz in 0..n_rz {
+                if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                    && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
+                {
+                    let d_r: f64 = conductor_d_r[i_conductor_rz];
+                    let d_z: f64 = conductor_d_z[i_conductor_rz];
+                    g_d3_psi_d_r_d_z2_local[i_rz] = -MU_0 * (4.0 * (d_r / d_z).atan() - 2.0 * d_r * d_z / (d_r.powi(2) + d_z.powi(2))) / (d_r * d_z);
                 }
+            }
 
-                // Self-point: pure toroidal-curvature (hoop) effect
-                // <d3_psi_d_r_d_z2> = -MU_0 * (4 * atan(d_r / d_z) - 2 * d_r * d_z / (d_r^2 + d_z^2)) / (d_r * d_z)
-                for i_rz in 0..n_rz {
-                    if (r[i_rz] - conductor_r[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                        && (z[i_rz] - conductor_z[i_conductor_rz]).abs() < SELF_POINT_DISTANCE_TOLERANCE
-                    {
-                        let d_r: f64 = conductor_d_r[i_conductor_rz];
-                        let d_z: f64 = conductor_d_z[i_conductor_rz];
-                        g_d3_psi_d_r_d_z2_local[i_rz] = -MU_0 * (4.0 * (d_r / d_z).atan() - 2.0 * d_r * d_z / (d_r.powi(2) + d_z.powi(2))) / (d_r * d_z);
-                    }
-                }
-
-                g_d3_psi_d_r_d_z2_local
-            })
-            .collect();
+            g_d3_psi_d_r_d_z2_local
+        });
 
         let mut g_d3_psi_d_r_d_z2: Array2<f64> = Array2::from_elem((n_rz, conductor_n_rz), f64::NAN);
         for i_conductor_rz in 0..conductor_n_rz {

--- a/rust/gsfit_rs/src/greens/mutual_inductance_finite_size_to_finite_size.rs
+++ b/rust/gsfit_rs/src/greens/mutual_inductance_finite_size_to_finite_size.rs
@@ -1,6 +1,7 @@
 use super::Greens;
 use super::filament_geometry::FilamentGeometry;
 use ndarray::{Array1, Array2, s};
+use rayon::prelude::*;
 
 /// Mutual inductance between filaments of finite size
 ///
@@ -44,50 +45,61 @@ pub fn mutual_inductance_finite_size_to_finite_size(
     // TODO: can this can be adjusted automatically to achieve a desired accuracy ??
     let n_sub_filaments: usize = 10;
 
+    // Each row of `g_psi` (one "first" filament against all "second" filaments) is independent, so the
+    // rows are computed in parallel. Every element is evaluated exactly as in the serial loop.
+    let g_psi_rows: Vec<Array1<f64>> = (0..n_filaments)
+        .into_par_iter()
+        .map(|i_filament: usize| {
+            let mut g_psi_row: Array1<f64> = Array1::from_elem(n_filaments_prime, f64::NAN);
+            // Discretise the first filament
+            let (r_sub_filament, z_sub_filament, _d_r_sub_filament, _d_z_sub_filament, _area): (Array1<f64>, Array1<f64>, Array1<f64>, Array1<f64>, f64) =
+                discretise_parallelogram(
+                    r[i_filament],
+                    z[i_filament],
+                    d_r[i_filament],
+                    d_z[i_filament],
+                    angle_1[i_filament],
+                    angle_2[i_filament],
+                    n_sub_filaments,
+                );
+
+            for i_filament_prime in 0..n_filaments_prime {
+                // Discretise the second filament
+                let (r_sub_filament_prime, z_sub_filament_prime, _d_r_sub_filament_prime, _d_z_sub_filament_prime, _area_prime): (
+                    Array1<f64>,
+                    Array1<f64>,
+                    Array1<f64>,
+                    Array1<f64>,
+                    f64,
+                ) = discretise_parallelogram(
+                    r_prime[i_filament_prime],
+                    z_prime[i_filament_prime],
+                    d_r_prime[i_filament_prime],
+                    d_z_prime[i_filament_prime],
+                    angle_1_prime[i_filament_prime],
+                    angle_2_prime[i_filament_prime],
+                    n_sub_filaments,
+                );
+
+                // Calculate the greens function for the sub-filaments to sub-filaments
+                let greens_calculator: Greens = Greens::sensor_to_conductor(
+                    r_sub_filament.clone(),
+                    z_sub_filament.clone(),
+                    r_sub_filament_prime.clone(),
+                    z_sub_filament_prime.clone(),
+                    r_sub_filament_prime.clone() * 0.0 + d_r[i_filament] / (n_sub_filaments as f64),
+                    z_sub_filament_prime.clone() * 0.0 + d_z[i_filament] / (n_sub_filaments as f64),
+                );
+                let g_sub_filaments: Array2<f64> = greens_calculator.psi(); // shape = [n_sub_filaments * n_sub_filaments, n_sub_filaments * n_sub_filaments]
+
+                g_psi_row[i_filament_prime] = g_sub_filaments.sum() / ((n_sub_filaments as f64).powi(4));
+            }
+            g_psi_row
+        })
+        .collect();
+
     for i_filament in 0..n_filaments {
-        // Discretise the first filament
-        let (r_sub_filament, z_sub_filament, _d_r_sub_filament, _d_z_sub_filament, _area): (Array1<f64>, Array1<f64>, Array1<f64>, Array1<f64>, f64) =
-            discretise_parallelogram(
-                r[i_filament],
-                z[i_filament],
-                d_r[i_filament],
-                d_z[i_filament],
-                angle_1[i_filament],
-                angle_2[i_filament],
-                n_sub_filaments,
-            );
-
-        for i_filament_prime in 0..n_filaments_prime {
-            // Discretise the second filament
-            let (r_sub_filament_prime, z_sub_filament_prime, _d_r_sub_filament_prime, _d_z_sub_filament_prime, _area_prime): (
-                Array1<f64>,
-                Array1<f64>,
-                Array1<f64>,
-                Array1<f64>,
-                f64,
-            ) = discretise_parallelogram(
-                r_prime[i_filament_prime],
-                z_prime[i_filament_prime],
-                d_r_prime[i_filament_prime],
-                d_z_prime[i_filament_prime],
-                angle_1_prime[i_filament_prime],
-                angle_2_prime[i_filament_prime],
-                n_sub_filaments,
-            );
-
-            // Calculate the greens function for the sub-filaments to sub-filaments
-            let greens_calculator: Greens = Greens::sensor_to_conductor(
-                r_sub_filament.clone(),
-                z_sub_filament.clone(),
-                r_sub_filament_prime.clone(),
-                z_sub_filament_prime.clone(),
-                r_sub_filament_prime.clone() * 0.0 + d_r[i_filament] / (n_sub_filaments as f64),
-                z_sub_filament_prime.clone() * 0.0 + d_z[i_filament] / (n_sub_filaments as f64),
-            );
-            let g_sub_filaments: Array2<f64> = greens_calculator.psi(); // shape = [n_sub_filaments * n_sub_filaments, n_sub_filaments * n_sub_filaments]
-
-            g_psi[(i_filament, i_filament_prime)] = g_sub_filaments.sum() / ((n_sub_filaments as f64).powi(4));
-        }
+        g_psi.slice_mut(s![i_filament, ..]).assign(&g_psi_rows[i_filament]);
     }
 
     g_psi

--- a/rust/gsfit_rs/src/plasma.rs
+++ b/rust/gsfit_rs/src/plasma.rs
@@ -21,6 +21,7 @@ use numpy::borrow::PyReadonlyArray1;
 use numpy::{PyArray1, PyArray2, PyArray3};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
+use rayon::prelude::*;
 use std::f64::consts::PI;
 
 const MU_0: f64 = physical_constants::VACUUM_MAG_PERMEABILITY;
@@ -39,6 +40,24 @@ pub struct Plasma {
 }
 
 // Python accessible methods
+/// Per-time-slice results of the expensive part of the equilibrium post-processing
+/// (see `Plasma::equilibrium_post_processor`); calculated in parallel over the time-slices
+struct PostProcessedSlice {
+    boundary_contour: MarchingContour,
+    f_profile: Array1<f64>,
+    volume_profile: Array1<f64>,
+    volume_prime_profile: Array1<f64>,
+    area_profile: Array1<f64>,
+    area_prime_profile: Array1<f64>,
+    q_profile: Array1<f64>,
+    q_profile_vacuum: Array1<f64>,
+    bp_sq_fs_avg: f64,
+    hfs_leg_r: Array1<f64>,
+    hfs_leg_z: Array1<f64>,
+    lfs_leg_r: Array1<f64>,
+    lfs_leg_z: Array1<f64>,
+}
+
 #[pymethods]
 impl Plasma {
     /// Create a new Plasma instance
@@ -1028,6 +1047,8 @@ impl Plasma {
 
         // Get the mesh (note, the [0] is because the mesh is the same for all time slices)
         let time: Array1<f64> = plasma.results.get("time").unwrap_array1();
+        // TF rod current per time-slice (needed by the parallel post-processing below)
+        let i_rod: Array1<f64> = coils.results.get("tf").get("rod_i").get("measured").get("value").unwrap_array1();
         let d_area: f64 = plasma.results.get("grid").get("d_area").unwrap_f64();
         let r_mesh: Array2<f64> = plasma.results.get("grid").get("mesh").get("r").unwrap_array2();
         let z_mesh: Array2<f64> = plasma.results.get("grid").get("mesh").get("z").unwrap_array2();
@@ -1098,6 +1119,123 @@ impl Plasma {
 
         let mut xpt_diverted: Vec<bool> = Vec::with_capacity(n_time);
 
+        // The boundary contour, the flux-surface contouring and the profiles derived from it, and the
+        // scrape-off-layer legs depend only on each time-slice's own solution and dominate the
+        // post-processing cost, so they are calculated in parallel over the time-slices here; the
+        // serial loop below then only assembles results. The arithmetic is unchanged.
+        let plasma_for_scrape_off_layer: &Plasma = self;
+        let gs_solutions_shared: &[GsSolution] = gs_solutions;
+        let post_processed_slices: Vec<PostProcessedSlice> = (0..n_time)
+            .into_par_iter()
+            .map(|i_time: usize| {
+                let gs_solution: &GsSolution = &gs_solutions_shared[i_time];
+                let empty_1d = || Array1::from_elem(0, f64::NAN);
+                let mut post_processed_slice: PostProcessedSlice = PostProcessedSlice {
+                    boundary_contour: MarchingContour {
+                        r: empty_1d(),
+                        z: empty_1d(),
+                        n: 0,
+                    },
+                    f_profile: empty_1d(),
+                    volume_profile: empty_1d(),
+                    volume_prime_profile: empty_1d(),
+                    area_profile: empty_1d(),
+                    area_prime_profile: empty_1d(),
+                    q_profile: empty_1d(),
+                    q_profile_vacuum: empty_1d(),
+                    bp_sq_fs_avg: f64::NAN,
+                    hfs_leg_r: empty_1d(),
+                    hfs_leg_z: empty_1d(),
+                    lfs_leg_r: empty_1d(),
+                    lfs_leg_z: empty_1d(),
+                };
+                // Time-slices which didn't converge are skipped, as in the loop below
+                if gs_solution.psi_a.is_nan() {
+                    return post_processed_slice;
+                }
+                let psi_a_local: f64 = gs_solution.psi_a;
+                let psi_b_local: f64 = gs_solution.psi_b;
+
+                post_processed_slice.f_profile = epp_f_profile(gs_solution, &psi_n, psi_a_local, psi_b_local, i_rod[i_time]);
+
+                let psi_profile_local: Array1<f64> = &psi_n * (psi_b_local - psi_a_local) + psi_a_local;
+                let d_psi: f64 = psi_profile_local[1] - psi_profile_local[0];
+
+                // Find plasma boundary
+                let r_xpt_local: Option<f64>;
+                let z_xpt_local: Option<f64>;
+                if gs_solution.xpt_diverted {
+                    r_xpt_local = Some(gs_solution.bounding_r);
+                    z_xpt_local = Some(gs_solution.bounding_z);
+                } else {
+                    r_xpt_local = None;
+                    z_xpt_local = None;
+                }
+                let boundary_contour_local: MarchingContour = marching_squares(
+                    &r,
+                    &z,
+                    &gs_solution.psi_2d,
+                    &gs_solution.d_psi_d_r_2d,
+                    &gs_solution.d_psi_d_z_2d,
+                    psi_b_local,
+                    &gs_solution.mask,
+                    r_xpt_local,
+                    z_xpt_local,
+                    gs_solution.r_mag,
+                    gs_solution.z_mag,
+                );
+                let boundary_contour_is_finite: bool = boundary_contour_local
+                    .r
+                    .iter()
+                    .chain(boundary_contour_local.z.iter())
+                    .all(|value| value.is_finite());
+                let boundary_is_valid: bool = boundary_contour_local.n != 0 && boundary_contour_is_finite;
+                post_processed_slice.boundary_contour = boundary_contour_local;
+                if !boundary_is_valid {
+                    return post_processed_slice;
+                }
+                let boundary_contour_local: &MarchingContour = &post_processed_slice.boundary_contour;
+
+                // Volume and area profiles
+                let (volume_profile_local, volume_prime_profile_local, area_profile_local, area_prime_profile_local): (
+                    Array1<f64>,
+                    Array1<f64>,
+                    Array1<f64>,
+                    Array1<f64>,
+                ) = epp_vol_profile(gs_solution, &boundary_contour_local.r, &boundary_contour_local.z, &psi_n, &r, &z, d_psi);
+
+                // Flux surfaces and the safety factor (plasma, and vacuum toroidal field for the diamagnetic flux)
+                let flux_surfaces: Vec<FluxSurface> = epp_flux_surfaces(gs_solution, &boundary_contour_local.r, &boundary_contour_local.z, &psi_n, &r, &z);
+                post_processed_slice.q_profile = epp_q_profile(gs_solution, &flux_surfaces, &post_processed_slice.f_profile, &r, &z);
+                let f_profile_vacuum: Array1<f64> = 0.0 * &post_processed_slice.f_profile + MU_0 * i_rod[i_time] / (2.0 * PI);
+                post_processed_slice.q_profile_vacuum = epp_q_profile(gs_solution, &flux_surfaces, &f_profile_vacuum, &r, &z);
+
+                // Flux-surface-averaged b_p ** 2, used for beta_p(1) and li(1).
+                // Evaluated slightly inside the boundary because b_p = 0 at the x-point,
+                // which lies on the boundary for diverted plasmas, making `∮ d_ell / b_p`
+                // log-divergent on the separatrix
+                let bp_sq_fs_avg_psi_n: f64 = 0.995;
+                post_processed_slice.bp_sq_fs_avg =
+                    epp_bp_sq_flux_surface_average(gs_solution, &boundary_contour_local.r, &boundary_contour_local.z, bp_sq_fs_avg_psi_n, &r, &z);
+
+                // Scrape-off-layer legs
+                if gs_solution.xpt_diverted {
+                    let (hfs_leg_r, hfs_leg_z, lfs_leg_r, lfs_leg_z): (Array1<f64>, Array1<f64>, Array1<f64>, Array1<f64>) =
+                        epp_scrape_off_layer(gs_solution, plasma_for_scrape_off_layer);
+                    post_processed_slice.hfs_leg_r = hfs_leg_r;
+                    post_processed_slice.hfs_leg_z = hfs_leg_z;
+                    post_processed_slice.lfs_leg_r = lfs_leg_r;
+                    post_processed_slice.lfs_leg_z = lfs_leg_z;
+                }
+
+                post_processed_slice.volume_profile = volume_profile_local;
+                post_processed_slice.volume_prime_profile = volume_prime_profile_local;
+                post_processed_slice.area_profile = area_profile_local;
+                post_processed_slice.area_prime_profile = area_prime_profile_local;
+                post_processed_slice
+            })
+            .collect();
+
         // Loop over time, and perform post-processing on `gs_solutions`
         let mut p_2d: Array3<f64> = Array3::from_elem((n_time, n_z, n_r), f64::NAN);
         let mut bt_2d: Array3<f64> = Array3::from_elem((n_time, n_z, n_r), f64::NAN);
@@ -1136,8 +1274,6 @@ impl Plasma {
         let mut lfs_legs_r: Vec<Array1<f64>> = Vec::with_capacity(n_time);
         let mut lfs_legs_z: Vec<Array1<f64>> = Vec::with_capacity(n_time);
         let mut lfs_legs_n: Vec<usize> = vec![0; n_time];
-
-        let i_rod: Array1<f64> = coils.results.get("tf").get("rod_i").get("measured").get("value").unwrap_array1();
 
         let mut boundary_contours: Vec<MarchingContour> = Vec::with_capacity(n_time);
 
@@ -1219,7 +1355,7 @@ impl Plasma {
             p_1d[i_time] = p_2d.slice(s![i_time, .., ..]).sum();
 
             // Profiles
-            let f_profile_local: Array1<f64> = epp_f_profile(&gs_solutions[i_time], &psi_n, psi_a[i_time], psi_b[i_time], i_rod[i_time]);
+            let f_profile_local: Array1<f64> = post_processed_slices[i_time].f_profile.clone();
             f_profile.slice_mut(s![i_time, ..]).assign(&f_profile_local);
 
             let ff_prime_profile_local: Array1<f64> = epp_ff_prime_profile(&gs_solutions[i_time], &psi_n);
@@ -1251,36 +1387,8 @@ impl Plasma {
             let (bt_2d_this_time, _bt_vac_this_time): (Array2<f64>, Array2<f64>) = epp_bt_2d(&gs_solutions[i_time], &r, &z, i_rod[i_time]);
             bt_2d.slice_mut(s![i_time, .., ..]).assign(&bt_2d_this_time);
 
-            // Find plasma boundary
-            let psi_2d_local: Array2<f64> = psi_2d.slice(s![i_time, .., ..]).to_owned();
-            let mask_2d_local: Array2<f64> = mask_2d.slice(s![i_time, .., ..]).to_owned();
-            let psi_b_local: f64 = gs_solutions[i_time].psi_b;
-
-            let r_xpt_local: Option<f64>;
-            let z_xpt_local: Option<f64>;
-            if xpt_diverted[i_time] {
-                r_xpt_local = Some(bounding_r[i_time]);
-                z_xpt_local = Some(bounding_z[i_time]);
-            } else {
-                r_xpt_local = None;
-                z_xpt_local = None;
-            }
-            let mag_r_local: f64 = r_mag[i_time];
-            let mag_z_local: f64 = z_mag[i_time];
-
-            let boundary_contour_local: MarchingContour = marching_squares(
-                &r,
-                &z,
-                &psi_2d_local,
-                &gs_solutions[i_time].d_psi_d_r_2d,
-                &gs_solutions[i_time].d_psi_d_z_2d,
-                psi_b_local,
-                &mask_2d_local,
-                r_xpt_local,
-                z_xpt_local,
-                mag_r_local,
-                mag_z_local,
-            );
+            // Plasma boundary (calculated in parallel above)
+            let boundary_contour_local: MarchingContour = post_processed_slices[i_time].boundary_contour.clone();
             boundary_contours.push(boundary_contour_local.clone());
             // Defensive programming: when a time-slice has failed the boundary contour can be
             // empty, or contain NAN's or junk; skip further post-processing for this time slice
@@ -1304,20 +1412,10 @@ impl Plasma {
             // Plasma volume
             // plasma_volume[i_time] = epp_plasma_volume(&gs_solutions[i_time], r_geo[i_time]);
 
-            let (volume_profile_this_time, volume_prime_profile_this_time, area_profile_this_time, area_prime_profile_this_time): (
-                Array1<f64>,
-                Array1<f64>,
-                Array1<f64>,
-                Array1<f64>,
-            ) = epp_vol_profile(
-                &gs_solutions[i_time],
-                &boundary_contour_local.r,
-                &boundary_contour_local.z,
-                &psi_n,
-                &r,
-                &z,
-                d_psi,
-            );
+            let volume_profile_this_time: Array1<f64> = post_processed_slices[i_time].volume_profile.clone();
+            let volume_prime_profile_this_time: Array1<f64> = post_processed_slices[i_time].volume_prime_profile.clone();
+            let area_profile_this_time: Array1<f64> = post_processed_slices[i_time].area_profile.clone();
+            let area_prime_profile_this_time: Array1<f64> = post_processed_slices[i_time].area_prime_profile.clone();
             area_profile.slice_mut(s![i_time, ..]).assign(&area_profile_this_time);
             area_prime_profile.slice_mut(s![i_time, ..]).assign(&area_prime_profile_this_time);
             volume_profile.slice_mut(s![i_time, ..]).assign(&volume_profile_this_time);
@@ -1325,10 +1423,7 @@ impl Plasma {
 
             plasma_volume[i_time] = volume_profile_this_time.last().unwrap().to_owned();
 
-            let flux_surfaces: Vec<FluxSurface> =
-                epp_flux_surfaces(&gs_solutions[i_time], &boundary_contour_local.r, &boundary_contour_local.z, &psi_n, &r, &z);
-
-            let q_profile_this_time: Array1<f64> = epp_q_profile(&gs_solutions[i_time], &flux_surfaces, &f_profile_local, &r, &z);
+            let q_profile_this_time: Array1<f64> = post_processed_slices[i_time].q_profile.clone();
             q_profile.slice_mut(s![i_time, ..]).assign(&q_profile_this_time);
 
             let flux_tor_profile_this_time_slice: Array1<f64> = epp_flux_toroidal_profile(&q_profile_this_time, &psi_profile_this_time);
@@ -1336,8 +1431,7 @@ impl Plasma {
 
             // TODO: this is **VERY** hacky, and **SHOULD** be improved!!
             // set f_profile to the vacuum profile, then calculate the vacuum q-profile, then the vacuum toroidal flux
-            let f_profile_vacuum: Array1<f64> = 0.0 * &f_profile_local + MU_0 * i_rod[i_time] / (2.0 * PI);
-            let q_profile_vacuum: Array1<f64> = epp_q_profile(&gs_solutions[i_time], &flux_surfaces, &f_profile_vacuum, &r, &z);
+            let q_profile_vacuum: Array1<f64> = post_processed_slices[i_time].q_profile_vacuum.clone();
             let flux_tor_profile_vacuum: Array1<f64> = epp_flux_toroidal_profile(&q_profile_vacuum, &psi_profile_this_time);
             flux_dia[i_time] = flux_tor_profile_this_time_slice.last().unwrap().to_owned() - flux_tor_profile_vacuum.last().unwrap().to_owned();
 
@@ -1373,15 +1467,8 @@ impl Plasma {
             // Evaluated slightly inside the boundary because b_p = 0 at the x-point,
             // which lies on the boundary for diverted plasmas, making `∮ d_ell / b_p`
             // log-divergent on the separatrix
-            let bp_sq_fs_avg_psi_n: f64 = 0.995;
-            let bp_sq_fs_avg: f64 = epp_bp_sq_flux_surface_average(
-                &gs_solutions[i_time],
-                &boundary_contour_local.r,
-                &boundary_contour_local.z,
-                bp_sq_fs_avg_psi_n,
-                &r,
-                &z,
-            );
+            // (calculated in parallel above)
+            let bp_sq_fs_avg: f64 = post_processed_slices[i_time].bp_sq_fs_avg;
 
             // Plasma beta (must be after r_geo and plasma_volume are computed)
             (beta_p_1[i_time], beta_p_2[i_time], beta_p_3[i_time]) =
@@ -1410,24 +1497,11 @@ impl Plasma {
             let beta_n_this_time_slice: f64 = epp_beta_n(beta_t_this_time_slice, r_minor[i_time], bt_vac_at_r_geo[i_time], ip[i_time]);
             beta_n[i_time] = beta_n_this_time_slice;
 
-            // Find SOL boundary contour
-            if gs_solutions[i_time].xpt_diverted {
-                let (hfs_leg_r, hfs_leg_z, lfs_leg_r, lfs_leg_z): (Array1<f64>, Array1<f64>, Array1<f64>, Array1<f64>) =
-                    epp_scrape_off_layer(&gs_solutions[i_time], &self);
-                hfs_legs_r.push(hfs_leg_r);
-                hfs_legs_z.push(hfs_leg_z);
-                lfs_legs_r.push(lfs_leg_r);
-                lfs_legs_z.push(lfs_leg_z);
-            } else {
-                let hfs_leg_r: Array1<f64> = Array1::from_elem(0, f64::NAN);
-                let hfs_leg_z: Array1<f64> = Array1::from_elem(0, f64::NAN);
-                let lfs_leg_r: Array1<f64> = Array1::from_elem(0, f64::NAN);
-                let lfs_leg_z: Array1<f64> = Array1::from_elem(0, f64::NAN);
-                hfs_legs_r.push(hfs_leg_r);
-                hfs_legs_z.push(hfs_leg_z);
-                lfs_legs_r.push(lfs_leg_r);
-                lfs_legs_z.push(lfs_leg_z);
-            }
+            // SOL boundary contour (calculated in parallel above; empty arrays when not diverted)
+            hfs_legs_r.push(post_processed_slices[i_time].hfs_leg_r.clone());
+            hfs_legs_z.push(post_processed_slices[i_time].hfs_leg_z.clone());
+            lfs_legs_r.push(post_processed_slices[i_time].lfs_leg_r.clone());
+            lfs_legs_z.push(post_processed_slices[i_time].lfs_leg_z.clone());
         }
 
         // Find the longest div leg

--- a/rust/gsfit_rs/src/plasma.rs
+++ b/rust/gsfit_rs/src/plasma.rs
@@ -461,6 +461,33 @@ impl Plasma {
             let passive_r: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("r").unwrap_array1();
             let passive_z: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("z").unwrap_array1();
 
+            // Green's table between the grid and this passive's filaments.
+            // The table depends only on the geometry, so it is calculated once per passive and
+            // contracted with each degree of freedom's current distribution below.
+            let greens_calculator: Greens = Greens::sensor_to_conductor(
+                flat_r.clone(),
+                flat_z.clone(),
+                passive_r.clone(),
+                passive_z.clone(),
+                passive_r.clone() * f64::NAN, // d_r=0; as there will not be any points which coincide; using NaN as safety - if we get NaN's we know we have a problem
+                passive_z.clone() * f64::NAN, // d_z=0; as there will not be any points which coincide; using NaN as safety - if we get NaN's we know we have a problem
+            );
+
+            // Green's functions for `psi`, `b_r`, `b_z`, and derivatives
+            let g_psi_filaments: Array2<f64> = greens_calculator.psi(); // shape = [n_r * n_z, n_filament]
+            let g_br_filaments: Array2<f64> = greens_calculator.b_r(); // shape = [n_r * n_z, n_filament]
+            let g_bz_filaments: Array2<f64> = greens_calculator.b_z(); // shape = [n_r * n_z, n_filament]
+            let d_g_br_filaments_d_z: Array2<f64> = greens_calculator.d_b_r_d_z(); // shape = [n_r * n_z, n_filament]
+            let d_g_bz_filaments_d_z: Array2<f64> = greens_calculator.d_b_z_d_z(); // shape = [n_r * n_z, n_filament]
+            let g_d_psi_d_r_coil_filaments: Array2<f64> = greens_calculator.d_psi_d_r(); // shape = [n_r * n_z, n_filament]
+            let g_d_psi_d_z_coil_filaments: Array2<f64> = greens_calculator.d_psi_d_z(); // shape = [n_r * n_z, n_filament]
+            let g_d2_psi_d_r2_filaments: Array2<f64> = greens_calculator.d2_psi_d_r2(); // shape = [n_r * n_z, n_filament]
+            let g_d2_psi_d_r_d_z_filaments: Array2<f64> = greens_calculator.d2_psi_d_r_d_z(); // shape = [n_r * n_z, n_filament]
+            let g_d2_psi_d_z2_filaments: Array2<f64> = greens_calculator.d2_psi_d_z2(); // shape = [n_r * n_z, n_filament]
+            let g_d3_psi_d_r2_d_z_filaments: Array2<f64> = greens_calculator.d3_psi_d_r2_d_z(); // shape = [n_r * n_z, n_filament]
+            let g_d3_psi_d_r_d_z2_filaments: Array2<f64> = greens_calculator.d3_psi_d_r_d_z2(); // shape = [n_r * n_z, n_filament]
+            let g_d3_psi_d_z3_filaments: Array2<f64> = greens_calculator.d3_psi_d_z3(); // shape = [n_r * n_z, n_filament]
+
             for dof_name in dof_names {
                 // Current distribution
                 let current_distribution: Array1<f64> = passives_local
@@ -471,45 +498,20 @@ impl Plasma {
                     .get("current_distribution")
                     .unwrap_array1();
 
-                // Green's table
-                let greens_calculator: Greens = Greens::sensor_to_conductor(
-                    flat_r.clone(),
-                    flat_z.clone(),
-                    passive_r.clone(),
-                    passive_z.clone(),
-                    passive_r.clone() * f64::NAN, // d_r=0; as there will not be any points which coincide; using NaN as safety - if we get NaN's we know we have a problem
-                    passive_z.clone() * f64::NAN, // d_z=0; as there will not be any points which coincide; using NaN as safety - if we get NaN's we know we have a problem
-                );
-
-                // Green's functions for `psi`, `b_r`, `b_z`, and derivatives
-                let g_psi_filaments: Array2<f64> = greens_calculator.psi(); // shape = [n_r * n_z, n_filament]
-                let g_br_filaments: Array2<f64> = greens_calculator.b_r(); // shape = [n_r * n_z, n_filament]
-                let g_bz_filaments: Array2<f64> = greens_calculator.b_z(); // shape = [n_r * n_z, n_filament]
-                let d_g_br_filaments_d_z: Array2<f64> = greens_calculator.d_b_r_d_z(); // shape = [n_r * n_z, n_filament]
-                let d_g_bz_filaments_d_z: Array2<f64> = greens_calculator.d_b_z_d_z(); // shape = [n_r * n_z, n_filament]
-                let g_d_psi_d_r_coil_filaments: Array2<f64> = greens_calculator.d_psi_d_r(); // shape = [n_r * n_z, n_filament]
-                let g_d_psi_d_z_coil_filaments: Array2<f64> = greens_calculator.d_psi_d_z(); // shape = [n_r * n_z, n_filament]
-                let g_d2_psi_d_r2_filaments: Array2<f64> = greens_calculator.d2_psi_d_r2(); // shape = [n_r * n_z, n_filament]
-                let g_d2_psi_d_r_d_z_filaments: Array2<f64> = greens_calculator.d2_psi_d_r_d_z(); // shape = [n_r * n_z, n_filament]
-                let g_d2_psi_d_z2_filaments: Array2<f64> = greens_calculator.d2_psi_d_z2(); // shape = [n_r * n_z, n_filament]
-                let g_d3_psi_d_r2_d_z_filaments: Array2<f64> = greens_calculator.d3_psi_d_r2_d_z(); // shape = [n_r * n_z, n_filament]
-                let g_d3_psi_d_r_d_z2_filaments: Array2<f64> = greens_calculator.d3_psi_d_r_d_z2(); // shape = [n_r * n_z, n_filament]
-                let g_d3_psi_d_z3_filaments: Array2<f64> = greens_calculator.d3_psi_d_z3(); // shape = [n_r * n_z, n_filament]
-
                 // Apply the current_distribution
-                let g_psi_filaments_with_dof: Array2<f64> = g_psi_filaments * &current_distribution; // shape = [n_r * n_z, n_filament]
+                let g_psi_filaments_with_dof: Array2<f64> = &g_psi_filaments * &current_distribution; // shape = [n_r * n_z, n_filament]
                 let g_br_filaments_with_dof: Array2<f64> = &g_br_filaments * &current_distribution; // shape = [n_r * n_z]
-                let g_bz_filaments_with_dof: Array2<f64> = g_bz_filaments * &current_distribution; // shape = [n_r * n_z]
-                let d_g_br_filaments_with_dof_d_z: Array2<f64> = d_g_br_filaments_d_z * &current_distribution; // shape = [n_r * n_z]
-                let d_g_bz_filaments_with_dof_d_z: Array2<f64> = d_g_bz_filaments_d_z * &current_distribution; // shape = [n_r * n_z]
-                let g_d_psi_d_r_coil_filaments_with_dof: Array2<f64> = g_d_psi_d_r_coil_filaments * &current_distribution; // shape = [n_r * n_z]
-                let g_d_psi_d_z_coil_filaments_with_dof: Array2<f64> = g_d_psi_d_z_coil_filaments * &current_distribution; // shape = [n_r * n_z]
-                let g_d2_psi_d_r2_filaments_with_dof: Array2<f64> = g_d2_psi_d_r2_filaments * &current_distribution; // shape = [n_r * n_z]
-                let g_d2_psi_d_r_d_z_filaments_with_dof: Array2<f64> = g_d2_psi_d_r_d_z_filaments * &current_distribution; // shape = [n_r * n_z]
-                let g_d2_psi_d_z2_filaments_with_dof: Array2<f64> = g_d2_psi_d_z2_filaments * &current_distribution; // shape = [n_r * n_z]
-                let g_d3_psi_d_r2_d_z_filaments_with_dof: Array2<f64> = g_d3_psi_d_r2_d_z_filaments * &current_distribution; // shape = [n_r * n_z]
-                let g_d3_psi_d_r_d_z2_filaments_with_dof: Array2<f64> = g_d3_psi_d_r_d_z2_filaments * &current_distribution; // shape = [n_r * n_z]
-                let g_d3_psi_d_z3_filaments_with_dof: Array2<f64> = g_d3_psi_d_z3_filaments * &current_distribution; // shape = [n_r * n_z]
+                let g_bz_filaments_with_dof: Array2<f64> = &g_bz_filaments * &current_distribution; // shape = [n_r * n_z]
+                let d_g_br_filaments_with_dof_d_z: Array2<f64> = &d_g_br_filaments_d_z * &current_distribution; // shape = [n_r * n_z]
+                let d_g_bz_filaments_with_dof_d_z: Array2<f64> = &d_g_bz_filaments_d_z * &current_distribution; // shape = [n_r * n_z]
+                let g_d_psi_d_r_coil_filaments_with_dof: Array2<f64> = &g_d_psi_d_r_coil_filaments * &current_distribution; // shape = [n_r * n_z]
+                let g_d_psi_d_z_coil_filaments_with_dof: Array2<f64> = &g_d_psi_d_z_coil_filaments * &current_distribution; // shape = [n_r * n_z]
+                let g_d2_psi_d_r2_filaments_with_dof: Array2<f64> = &g_d2_psi_d_r2_filaments * &current_distribution; // shape = [n_r * n_z]
+                let g_d2_psi_d_r_d_z_filaments_with_dof: Array2<f64> = &g_d2_psi_d_r_d_z_filaments * &current_distribution; // shape = [n_r * n_z]
+                let g_d2_psi_d_z2_filaments_with_dof: Array2<f64> = &g_d2_psi_d_z2_filaments * &current_distribution; // shape = [n_r * n_z]
+                let g_d3_psi_d_r2_d_z_filaments_with_dof: Array2<f64> = &g_d3_psi_d_r2_d_z_filaments * &current_distribution; // shape = [n_r * n_z]
+                let g_d3_psi_d_r_d_z2_filaments_with_dof: Array2<f64> = &g_d3_psi_d_r_d_z2_filaments * &current_distribution; // shape = [n_r * n_z]
+                let g_d3_psi_d_z3_filaments_with_dof: Array2<f64> = &g_d3_psi_d_z3_filaments * &current_distribution; // shape = [n_r * n_z]
 
                 // Sum over all filaments
                 let g_psi: Array1<f64> = g_psi_filaments_with_dof.sum_axis(Axis(1)); // shape = [n_r * n_z]

--- a/rust/gsfit_rs/src/plasma.rs
+++ b/rust/gsfit_rs/src/plasma.rs
@@ -1368,7 +1368,6 @@ impl Plasma {
             p_prime_profile.slice_mut(s![i_time, ..]).assign(&p_prime_profile_this_time);
 
             let psi_profile_this_time: Array1<f64> = &psi_n * (psi_b[i_time] - psi_a[i_time]) + psi_a[i_time];
-            let d_psi: f64 = psi_profile_this_time[1] - psi_profile_this_time[0];
             psi_profile.slice_mut(s![i_time, ..]).assign(&psi_profile_this_time);
 
             // Mid-plane profiles

--- a/rust/gsfit_rs/src/plasma_geometry/find_boundary.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/find_boundary.rs
@@ -73,8 +73,6 @@ pub fn find_boundary(
         limit_pts_z,
         mag_r,
         mag_z,
-        vessel_r,
-        vessel_z,
         mask_vessel_2d,
         stationary_points,
     );

--- a/rust/gsfit_rs/src/plasma_geometry/find_boundary.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/find_boundary.rs
@@ -16,6 +16,7 @@ use ndarray::{Array1, Array2};
 /// * `limit_pts_z` - Z coordinates of limiter points, [metre]
 /// * `vessel_r` - R coordinates of vessel points, [metre]
 /// * `vessel_z` - Z coordinates of vessel points, [metre]
+/// * `mask_vessel_2d` - `true` for grid points inside the vessel (from `vessel_mask`), shape = (n_z, n_r), dimensionless
 /// * `mag_r` - R coordinate of magnetic axis, [metre]
 /// * `mag_z` - Z coordinate of magnetic axis, [metre]
 ///
@@ -33,6 +34,7 @@ pub fn find_boundary(
     limit_pts_z: &Array1<f64>,
     vessel_r: &Array1<f64>,
     vessel_z: &Array1<f64>,
+    mask_vessel_2d: &Array2<bool>,
     mag_r: f64,
     mag_z: f64,
 ) -> Result<BoundaryContour, Error> {
@@ -73,6 +75,7 @@ pub fn find_boundary(
         mag_z,
         vessel_r,
         vessel_z,
+        mask_vessel_2d,
         stationary_points,
     );
 
@@ -155,7 +158,7 @@ pub fn find_boundary(
     }
 
     // Calculate the mask
-    let mask: Array2<f64> = flood_fill_mask(r, z, psi_2d, psi_b, stationary_points, mag_r, mag_z, vessel_r, vessel_z);
+    let mask: Array2<f64> = flood_fill_mask(r, z, psi_2d, psi_b, stationary_points, mag_r, mag_z, mask_vessel_2d);
 
     let boundary_contour: BoundaryContour = BoundaryContour {
         boundary_r: boundary_r.clone(),

--- a/rust/gsfit_rs/src/plasma_geometry/find_stationary_points_using_winding_number.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/find_stationary_points_using_winding_number.rs
@@ -267,6 +267,24 @@ pub fn find_stationary_points_using_winding_number(
             let i_z_lower: usize = i_z;
             let i_z_upper: usize = i_z + 1;
 
+            // A cell with no zero crossing on any of its four edges has no perimeter events, so its
+            // winding number is zero; skip it (this is the large majority of cells)
+            let i_edge_bottom: usize = i_z_lower * (n_r - 1) + i_r_left;
+            let i_edge_top: usize = i_z_upper * (n_r - 1) + i_r_left;
+            let i_edge_left: usize = i_z_lower * n_r + i_r_left;
+            let i_edge_right: usize = i_z_lower * n_r + i_r_right;
+            if d_psi_d_z_zero_horizontal[i_edge_bottom].is_empty()
+                && d_psi_d_r_zero_horizontal[i_edge_bottom].is_empty()
+                && d_psi_d_z_zero_horizontal[i_edge_top].is_empty()
+                && d_psi_d_r_zero_horizontal[i_edge_top].is_empty()
+                && d_psi_d_z_zero_vertical[i_edge_left].is_empty()
+                && d_psi_d_r_zero_vertical[i_edge_left].is_empty()
+                && d_psi_d_z_zero_vertical[i_edge_right].is_empty()
+                && d_psi_d_r_zero_vertical[i_edge_right].is_empty()
+            {
+                continue;
+            }
+
             // Walk the perimeter of the cell CCW: BL → BR → TR → TL → BL.
             // Track every time `br` or `bz` cross zero.
             // Each zero-crossing "event" changes `total_quarter_turns` by +/-1.

--- a/rust/gsfit_rs/src/plasma_geometry/find_stationary_points_using_winding_number.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/find_stationary_points_using_winding_number.rs
@@ -4,7 +4,6 @@ use super::cubic_interpolation::cubic_interpolation_v2;
 use crate::plasma_geometry::hessian;
 use ndarray::{Array2, ArrayView1, ArrayView2, s};
 use ndarray_stats::QuantileExt;
-use std::collections::HashMap;
 
 /// Finds stationary points: extrema's (minima or maxima) and saddle points
 /// TODO: improve documentation - can this method also find higher-order stationary points?
@@ -144,12 +143,18 @@ pub fn find_stationary_points_using_winding_number(
         }
     }
 
-    // key: (i_r_from, i_z_from, i_r_to, i_z_to)
-    // value: vector of crossing coordinates
+    // Zero crossings along every grid edge, stored densely (this is inside the Picard loop, so a hash map
+    // keyed by the edge end-points was a measurable cost):
+    // * horizontal edges `(i_r, i_z) -> (i_r + 1, i_z)` are indexed by `i_z * (n_r - 1) + i_r`
+    // * vertical edges `(i_r, i_z) -> (i_r, i_z + 1)` are indexed by `i_z * n_r + i_r`
+    let n_horizontal_edges: usize = n_z * (n_r - 1);
+    let n_vertical_edges: usize = (n_z - 1) * n_r;
     // `(r,z)` location where `d(psi)/d(z)=0`, along all edges
-    let mut d_psi_d_z_zero_coordinates: HashMap<(usize, usize, usize, usize), Vec<Coordinate>> = HashMap::new();
+    let mut d_psi_d_z_zero_horizontal: Vec<Vec<Coordinate>> = Vec::with_capacity(n_horizontal_edges);
+    let mut d_psi_d_z_zero_vertical: Vec<Vec<Coordinate>> = Vec::with_capacity(n_vertical_edges);
     // `(r,z)` location where `d(psi)/d(r)=0`, along all edges
-    let mut d_psi_d_r_zero_coordinates: HashMap<(usize, usize, usize, usize), Vec<Coordinate>> = HashMap::new();
+    let mut d_psi_d_r_zero_horizontal: Vec<Vec<Coordinate>> = Vec::with_capacity(n_horizontal_edges);
+    let mut d_psi_d_r_zero_vertical: Vec<Vec<Coordinate>> = Vec::with_capacity(n_vertical_edges);
 
     // Horizontal march: (i_r_left, i_z) → (i_r_right, i_z)
     // We don't need to do (i_r_left, i_z+1) → (i_r_right, i_z+1) as this will be covered by the next horizontal march
@@ -171,7 +176,8 @@ pub fn find_stationary_points_using_winding_number(
             for &r_cross in &d_psi_d_z_zero_crossings_this_edge {
                 crossing_coordinates_this_edge.push(Coordinate { r: r_cross, z: z[i_z] });
             }
-            d_psi_d_z_zero_coordinates.insert((i_r_left, i_z, i_r_right, i_z), crossing_coordinates_this_edge);
+            // Horizontal edges are visited in index order, so pushing matches `i_z * (n_r - 1) + i_r_left`
+            d_psi_d_z_zero_horizontal.push(crossing_coordinates_this_edge);
 
             let d_psi_d_r_zero_crossings_this_edge: Vec<f64> = cubic_interpolation_v2(
                 r[i_r_left],
@@ -186,7 +192,7 @@ pub fn find_stationary_points_using_winding_number(
             for &r_cross in &d_psi_d_r_zero_crossings_this_edge {
                 crossing_coordinates_this_edge.push(Coordinate { r: r_cross, z: z[i_z] });
             }
-            d_psi_d_r_zero_coordinates.insert((i_r_left, i_z, i_r_right, i_z), crossing_coordinates_this_edge);
+            d_psi_d_r_zero_horizontal.push(crossing_coordinates_this_edge);
         }
     }
 
@@ -221,7 +227,8 @@ pub fn find_stationary_points_using_winding_number(
                     crossing_coordinates_this_edge.push(Coordinate { r: r[i_r], z: z_cross });
                 }
             }
-            d_psi_d_z_zero_coordinates.insert((i_r, i_z_lower, i_r, i_z_upper), crossing_coordinates_this_edge);
+            // Vertical edges are visited in index order, so pushing matches `i_z_lower * n_r + i_r`
+            d_psi_d_z_zero_vertical.push(crossing_coordinates_this_edge);
 
             let bz_crossings_this_edge: Vec<f64> = cubic_interpolation_v2(
                 z_start,
@@ -238,13 +245,15 @@ pub fn find_stationary_points_using_winding_number(
                     crossing_coordinates_this_edge.push(Coordinate { r: r[i_r], z: z_cross });
                 }
             }
-            d_psi_d_r_zero_coordinates.insert((i_r, i_z_lower, i_r, i_z_upper), crossing_coordinates_this_edge);
+            d_psi_d_r_zero_vertical.push(crossing_coordinates_this_edge);
         }
     }
 
     // If no zero-crossings found, then so no stationary points are possible
-    let no_d_psi_d_z_zero_crossings: bool = d_psi_d_z_zero_coordinates.values().all(|crossings| crossings.is_empty());
-    let no_d_psi_d_r_zero_crossings: bool = d_psi_d_r_zero_coordinates.values().all(|crossings| crossings.is_empty());
+    let no_d_psi_d_z_zero_crossings: bool =
+        d_psi_d_z_zero_horizontal.iter().all(|crossings| crossings.is_empty()) && d_psi_d_z_zero_vertical.iter().all(|crossings| crossings.is_empty());
+    let no_d_psi_d_r_zero_crossings: bool =
+        d_psi_d_r_zero_horizontal.iter().all(|crossings| crossings.is_empty()) && d_psi_d_r_zero_vertical.iter().all(|crossings| crossings.is_empty());
     if no_d_psi_d_z_zero_crossings || no_d_psi_d_r_zero_crossings {
         return stationary_points;
     }
@@ -268,8 +277,8 @@ pub fn find_stationary_points_using_winding_number(
             // Bottom edge: BL → BR (r increasing at z = z[i_z]).
             // Bottom edge: (i_r_left, i_z_bottom) → (i_r_right, i_z_bottom)
             let bottom_events: Vec<CrossingKind> = combine_and_order_edge_events(
-                &d_psi_d_z_zero_coordinates[&(i_r_left, i_z_lower, i_r_right, i_z_lower)],
-                &d_psi_d_r_zero_coordinates[&(i_r_left, i_z_lower, i_r_right, i_z_lower)],
+                &d_psi_d_z_zero_horizontal[i_z_lower * (n_r - 1) + i_r_left],
+                &d_psi_d_r_zero_horizontal[i_z_lower * (n_r - 1) + i_r_left],
                 r[i_r],
                 r[i_r + 1],
                 true,
@@ -280,8 +289,8 @@ pub fn find_stationary_points_using_winding_number(
 
             // Right edge: BR → TR (z increasing at r = r[i_r+1]).
             let right_events: Vec<CrossingKind> = combine_and_order_edge_events(
-                &d_psi_d_z_zero_coordinates[&(i_r_right, i_z_lower, i_r_right, i_z_upper)],
-                &d_psi_d_r_zero_coordinates[&(i_r_right, i_z_lower, i_r_right, i_z_upper)],
+                &d_psi_d_z_zero_vertical[i_z_lower * n_r + i_r_right],
+                &d_psi_d_r_zero_vertical[i_z_lower * n_r + i_r_right],
                 z[i_z],
                 z[i_z + 1],
                 false,
@@ -292,8 +301,8 @@ pub fn find_stationary_points_using_winding_number(
 
             // Top edge: TR → TL (r decreasing at z = z[i_z+1]).
             let top_events: Vec<CrossingKind> = combine_and_order_edge_events(
-                &d_psi_d_z_zero_coordinates[&(i_r_left, i_z_upper, i_r_right, i_z_upper)],
-                &d_psi_d_r_zero_coordinates[&(i_r_left, i_z_upper, i_r_right, i_z_upper)],
+                &d_psi_d_z_zero_horizontal[i_z_upper * (n_r - 1) + i_r_left],
+                &d_psi_d_r_zero_horizontal[i_z_upper * (n_r - 1) + i_r_left],
                 r[i_r + 1],
                 r[i_r],
                 true,
@@ -304,8 +313,8 @@ pub fn find_stationary_points_using_winding_number(
 
             // Left edge: TL → BL (z decreasing at r = r[i_r]).
             let left_events: Vec<CrossingKind> = combine_and_order_edge_events(
-                &d_psi_d_z_zero_coordinates[&(i_r_left, i_z_lower, i_r_left, i_z_upper)],
-                &d_psi_d_r_zero_coordinates[&(i_r_left, i_z_lower, i_r_left, i_z_upper)],
+                &d_psi_d_z_zero_vertical[i_z_lower * n_r + i_r_left],
+                &d_psi_d_r_zero_vertical[i_z_lower * n_r + i_r_left],
                 z[i_z_upper],
                 z[i_z_lower],
                 false,

--- a/rust/gsfit_rs/src/plasma_geometry/find_viable_limit_point.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/find_viable_limit_point.rs
@@ -17,8 +17,7 @@ use ndarray_stats::QuantileExt;
 /// * `limit_pts_z` - Z coordinates of limiter points, [metre]
 /// * `mag_r` - R coordinate of magnetic axis, [metre]
 /// * `mag_z` - Z coordinate of magnetic axis, [metre]
-/// * `vessel_r` - R coordinates of vessel points, [metre]
-/// * `vessel_z` - Z coordinates of vessel points, [metre]
+/// * `mask_vessel_2d` - `true` for grid points inside the vessel (from `vessel_mask`), shape = (n_z, n_r), dimensionless
 /// * `stationary_points` - Vector of `StationaryPoint` objects representing stationary points in psi
 ///
 /// # Returns
@@ -34,8 +33,6 @@ pub fn find_viable_limit_point(
     limit_pts_z: &Array1<f64>,
     mag_r: f64,
     mag_z: f64,
-    vessel_r: &Array1<f64>,
-    vessel_z: &Array1<f64>,
     mask_vessel_2d: &Array2<bool>,
     stationary_points: &[StationaryPoint],
 ) -> Result<BoundaryContour, String> {

--- a/rust/gsfit_rs/src/plasma_geometry/find_viable_limit_point.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/find_viable_limit_point.rs
@@ -36,6 +36,7 @@ pub fn find_viable_limit_point(
     mag_z: f64,
     vessel_r: &Array1<f64>,
     vessel_z: &Array1<f64>,
+    mask_vessel_2d: &Array2<bool>,
     stationary_points: &[StationaryPoint],
 ) -> Result<BoundaryContour, String> {
     // TODO: add logic for negative plasma current
@@ -192,8 +193,7 @@ pub fn find_viable_limit_point(
             stationary_points,
             mag_r,
             mag_z,
-            vessel_r,
-            vessel_z,
+            mask_vessel_2d,
         );
         potential_limit_point.mask = Some(mask_2d.clone());
 

--- a/rust/gsfit_rs/src/plasma_geometry/flood_fill_mask.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/flood_fill_mask.rs
@@ -2,7 +2,6 @@ use super::StationaryPoint;
 use geo::{Contains, Coord, LineString, Point, Polygon};
 use ndarray::{Array1, Array2};
 use ndarray_stats::QuantileExt;
-use std::collections::HashMap;
 use std::collections::VecDeque;
 
 /// Mask of the grid points which lie inside the vacuum vessel
@@ -114,8 +113,12 @@ pub fn flood_fill_mask(
         near_boundary_test
     });
 
+    // Grid sizes
+    let n_r: usize = r.len();
+    let n_z: usize = z.len();
+
     // Label points we should not cross
-    let mut indices_do_not_cross: HashMap<(usize, usize), ()> = HashMap::new();
+    let mut do_not_cross_2d: Array2<bool> = Array2::from_elem((n_z, n_r), false);
     for stationary_point in stationary_points.iter() {
         // Find the nearest grid point to the stationary point
         let i_r_nearest: usize = stationary_point.i_r_nearest;
@@ -128,39 +131,36 @@ pub fn flood_fill_mask(
         // x-point could conceivably escape left/right too
         if z[i_z_nearest] > 0.0 {
             if i_r_nearest > 1 {
-                indices_do_not_cross.insert((i_z_nearest_upper, i_r_nearest - 2), ());
+                do_not_cross_2d[(i_z_nearest_upper, i_r_nearest - 2)] = true;
             }
             if i_r_nearest > 0 {
-                indices_do_not_cross.insert((i_z_nearest_upper, i_r_nearest - 1), ());
+                do_not_cross_2d[(i_z_nearest_upper, i_r_nearest - 1)] = true;
             }
-            indices_do_not_cross.insert((i_z_nearest_upper, i_r_nearest), ());
+            do_not_cross_2d[(i_z_nearest_upper, i_r_nearest)] = true;
             if i_r_nearest < r.len() - 1 {
-                indices_do_not_cross.insert((i_z_nearest_upper, i_r_nearest + 1), ());
+                do_not_cross_2d[(i_z_nearest_upper, i_r_nearest + 1)] = true;
             }
             if i_r_nearest < r.len() - 2 {
-                indices_do_not_cross.insert((i_z_nearest_upper, i_r_nearest + 2), ());
+                do_not_cross_2d[(i_z_nearest_upper, i_r_nearest + 2)] = true;
             }
         }
         if z[i_z_nearest] < 0.0 {
             if i_r_nearest > 1 {
-                indices_do_not_cross.insert((i_z_nearest_lower, i_r_nearest - 2), ());
+                do_not_cross_2d[(i_z_nearest_lower, i_r_nearest - 2)] = true;
             }
             if i_r_nearest > 0 {
-                indices_do_not_cross.insert((i_z_nearest_lower, i_r_nearest - 1), ());
+                do_not_cross_2d[(i_z_nearest_lower, i_r_nearest - 1)] = true;
             }
-            indices_do_not_cross.insert((i_z_nearest_lower, i_r_nearest), ());
+            do_not_cross_2d[(i_z_nearest_lower, i_r_nearest)] = true;
             if i_r_nearest < r.len() - 1 {
-                indices_do_not_cross.insert((i_z_nearest_lower, i_r_nearest + 1), ());
+                do_not_cross_2d[(i_z_nearest_lower, i_r_nearest + 1)] = true;
             }
             if i_r_nearest < r.len() - 2 {
-                indices_do_not_cross.insert((i_z_nearest_lower, i_r_nearest + 2), ());
+                do_not_cross_2d[(i_z_nearest_lower, i_r_nearest + 2)] = true;
             }
         }
     }
 
-    // Grid sizes
-    let n_r: usize = r.len();
-    let n_z: usize = z.len();
     let mut mask_2d: Array2<f64> = Array2::from_elem((n_z, n_r), 0.0);
 
     // Find the index of the grid point closest to the magnetic axis
@@ -220,14 +220,14 @@ pub fn flood_fill_mask(
             }
 
             // Check if we are going past a saddle point
-            if indices_do_not_cross.contains_key(&(new_i_z, new_i_r)) {
+            if do_not_cross_2d[(new_i_z, new_i_r)] {
                 // Don't add this point to the `mask`, and don't add it to the `queue`
                 continue 'loop_over_directions;
             }
 
             if mask_2d[(new_i_z, new_i_r)] == 0.0 && psi_2d[(new_i_z, new_i_r)] > psi_b {
                 // `mask` is not allowed to pass a saddle point, regardless of if the plasma is diverted or limited
-                if !indices_do_not_cross.contains_key(&(new_i_z, new_i_r)) {
+                if !do_not_cross_2d[(new_i_z, new_i_r)] {
                     mask_2d[(new_i_z, new_i_r)] = 1.0;
                     queue.push_back((new_i_z, new_i_r));
                 }

--- a/rust/gsfit_rs/src/plasma_geometry/flood_fill_mask.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/flood_fill_mask.rs
@@ -5,6 +5,45 @@ use ndarray_stats::QuantileExt;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
+/// Mask of the grid points which lie inside the vacuum vessel
+///
+/// The flood fill stops at the vessel wall, so this mask is needed by `flood_fill_mask`. It depends
+/// only on the grid and vessel geometry, so it is calculated once per reconstruction and shared by
+/// every time-slice and Picard iteration.
+///
+/// # Arguments
+/// * `r` - R grid points, [metre]
+/// * `z` - Z grid points, [metre]
+/// * `vessel_r` - R coordinates of vessel points, [metre]
+/// * `vessel_z` - Z coordinates of vessel points, [metre]
+///
+/// # Returns
+/// * `mask_vessel_2d` - `true` for grid points inside the vessel, shape = (n_z, n_r), dimensionless
+pub fn vessel_mask(r: &Array1<f64>, z: &Array1<f64>, vessel_r: &Array1<f64>, vessel_z: &Array1<f64>) -> Array2<bool> {
+    let n_r: usize = r.len();
+    let n_z: usize = z.len();
+    let n_vessel_pts: usize = vessel_r.len();
+    let mut vessel_coords: Vec<Coord<f64>> = Vec::with_capacity(n_vessel_pts);
+    for i_vessel in 0..n_vessel_pts {
+        vessel_coords.push(Coord {
+            x: vessel_r[i_vessel],
+            y: vessel_z[i_vessel],
+        });
+    }
+    let vessel_polygon: Polygon = Polygon::new(
+        LineString::from(vessel_coords),
+        vec![], // No holes
+    );
+    let mut mask_vessel_2d: Array2<bool> = Array2::from_elem((n_z, n_r), false);
+    for i_z in 0..n_z {
+        for i_r in 0..n_r {
+            let test_point: Point = Point::new(r[i_r], z[i_z]);
+            mask_vessel_2d[(i_z, i_r)] = vessel_polygon.contains(&test_point);
+        }
+    }
+    mask_vessel_2d
+}
+
 /// Flood fill algorithm to create a mask of points inside the plasma boundary
 /// starting from the magnetic axis location
 /// * mask=0.0 --> outside the plasma
@@ -18,8 +57,7 @@ use std::collections::VecDeque;
 /// * `stationary_points` - Vector of `StationaryPoint` objects (including maxima/minima, and can include saddle points)
 /// * `mag_r_previous` - R coordinate of magnetic axis from previous iteration, [metre]
 /// * `mag_z_previous` - Z coordinate of magnetic axis from previous iteration, [metre]
-/// * `vessel_r` - R coordinates of vessel points, [metre]
-/// * `vessel_z` - Z coordinates of vessel points, [metre]
+/// * `mask_vessel_2d` - `true` for grid points inside the vacuum vessel, from `vessel_mask`, shape = (n_z, n_r), dimensionless
 ///
 /// # Returns
 /// * `mask_2d` - 1.0 = inside plasma boundary, 0.0 for points outside plasma boundary; f64 to make multiplication easier, shape = (n_z, n_r), dimensionless
@@ -36,8 +74,7 @@ pub fn flood_fill_mask(
     stationary_points: &[StationaryPoint],
     mag_r_previous: f64, // Note: mag_r and mag_z are from previous iteration; this can be a problem if the magnetic axis moves significantly
     mag_z_previous: f64, // which can happen when the plasma is significantly displaced vertically from the initial guess location, e.g. during a VDE
-    vessel_r: &Array1<f64>,
-    vessel_z: &Array1<f64>,
+    mask_vessel_2d: &Array2<bool>,
 ) -> Array2<f64> {
     // TODO 1: Is there a problem left/right of the x-point?
     // TODO 2: Perhaps start the fill between the x-point and the previous magnetic axis location,
@@ -125,27 +162,6 @@ pub fn flood_fill_mask(
     let n_r: usize = r.len();
     let n_z: usize = z.len();
     let mut mask_2d: Array2<f64> = Array2::from_elem((n_z, n_r), 0.0);
-
-    // Pre-compute a mask for points that lie inside the vessel so we can stop flood fill steps at the wall
-    let n_vessel_pts: usize = vessel_r.len();
-    let mut vessel_coords: Vec<Coord<f64>> = Vec::with_capacity(n_vessel_pts);
-    for i_vessel in 0..n_vessel_pts {
-        vessel_coords.push(Coord {
-            x: vessel_r[i_vessel],
-            y: vessel_z[i_vessel],
-        });
-    }
-    let vessel_polygon: Polygon = Polygon::new(
-        LineString::from(vessel_coords),
-        vec![], // No holes
-    );
-    let mut mask_vessel_2d: Array2<bool> = Array2::from_elem((n_z, n_r), false);
-    for i_z in 0..n_z {
-        for i_r in 0..n_r {
-            let test_point: Point = Point::new(r[i_r], z[i_z]);
-            mask_vessel_2d[(i_z, i_r)] = vessel_polygon.contains(&test_point);
-        }
-    }
 
     // Find the index of the grid point closest to the magnetic axis
     let i_r_nearest_mag: usize = (r - mag_r_previous).abs().argmin().unwrap();
@@ -256,7 +272,8 @@ fn test_flood_fill_mask() {
     let mag_r_previous: f64 = 0.5115792196972574;
     let mag_z_previous: f64 = -0.007343976139471093;
 
-    let mask_2d: Array2<f64> = flood_fill_mask(&r, &z, &psi_2d, psi_b, &stationary_points, mag_r_previous, mag_z_previous, &vessel_r, &vessel_z);
+    let mask_vessel_2d: Array2<bool> = vessel_mask(&r, &z, &vessel_r, &vessel_z);
+    let mask_2d: Array2<f64> = flood_fill_mask(&r, &z, &psi_2d, psi_b, &stationary_points, mag_r_previous, mag_z_previous, &mask_vessel_2d);
 
     let total_number_of_painted_cells: f64 = mask_2d.sum();
     assert_eq!(

--- a/rust/gsfit_rs/src/plasma_geometry/mod.rs
+++ b/rust/gsfit_rs/src/plasma_geometry/mod.rs
@@ -25,6 +25,7 @@ pub use find_magnetic_axis::find_magnetic_axis;
 pub use find_stationary_points_using_winding_number::find_stationary_points_using_winding_number;
 pub use find_viable_xpt::find_viable_xpt;
 pub use flood_fill_mask::flood_fill_mask;
+pub use flood_fill_mask::vessel_mask;
 pub use hessian::hessian;
 
 // Define the possible **external** failures this module can produce

--- a/rust/gsfit_rs/src/sensors/bp_probes.rs
+++ b/rust/gsfit_rs/src/sensors/bp_probes.rs
@@ -303,6 +303,41 @@ impl BpProbes {
         let sensor_names: Vec<String> = include_indices.iter().map(|&index| sensor_names_all[index].clone()).collect();
         let n_sensors: usize = sensor_names.len();
 
+        // Time dependent: interpolate all sensors (included or not) to `times_to_reconstruct` and store the
+        // measured values, so that they are available for the sensor post-processing even when no sensor
+        // of this type is included in the fit
+        let mut measured: Array2<f64> = Array2::from_elem((n_sensors_all, n_time), f64::NAN);
+        for i_sensor in 0..n_sensors_all {
+            // Sensor names
+            let sensor_name: &str = &sensor_names_all[i_sensor];
+
+            // Measured values
+            let experimental_time: Array1<f64> = self.results.get(sensor_name).get("b").get("experimental").get("time").unwrap_array1();
+            let experimental_values: Array1<f64> = self.results.get(sensor_name).get("b").get("experimental").get("value").unwrap_array1();
+
+            // Create the interpolator
+            let interpolator: interpolation::Dim1Linear =
+                interpolation::Dim1Linear::new(experimental_time.clone(), experimental_values.clone()).expect("Can't make interpolator");
+
+            // Do the interpolation
+            let measured_this_sensor: Array1<f64> = interpolator.interpolate_array1(times_to_reconstruct).expect("Can't do interpolation");
+
+            // Store for later
+            measured.slice_mut(s![i_sensor, ..]).assign(&measured_this_sensor);
+
+            // Store in self
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("b")
+                .get_or_insert("measured")
+                .insert("value", measured_this_sensor);
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("b")
+                .get_or_insert("measured")
+                .insert("time", times_to_reconstruct.clone());
+        }
+
         // If there are no sensors selected, return empty data
         if n_sensors == 0 {
             let (static_data_empty, dynamic_data_empty): (SensorsStatic, SensorsDynamic) = create_empty_sensor_data();
@@ -378,40 +413,6 @@ impl BpProbes {
             geometry_r: Array1::from_elem(n_sensors, f64::NAN), // not used for BpProbes
             geometry_z: Array1::from_elem(n_sensors, f64::NAN), // not used for BpProbes
         };
-
-        // Time dependent
-        // Interpolate all sensors to `times_to_reconstruct`
-        let mut measured: Array2<f64> = Array2::from_elem((n_sensors_all, n_time), f64::NAN);
-        for i_sensor in 0..n_sensors_all {
-            // Sensor names
-            let sensor_name: &str = &sensor_names_all[i_sensor];
-
-            // Measured values
-            let experimental_time: Array1<f64> = self.results.get(sensor_name).get("b").get("experimental").get("time").unwrap_array1();
-            let experimental_values: Array1<f64> = self.results.get(sensor_name).get("b").get("experimental").get("value").unwrap_array1();
-
-            // Create the interpolator
-            let interpolator: interpolation::Dim1Linear =
-                interpolation::Dim1Linear::new(experimental_time.clone(), experimental_values.clone()).expect("Can't make interpolator");
-
-            // Do the interpolation
-            let measured_this_sensor: Array1<f64> = interpolator.interpolate_array1(times_to_reconstruct).expect("Can't do interpolation");
-
-            // Store for later
-            measured.slice_mut(s![i_sensor, ..]).assign(&measured_this_sensor);
-
-            // Store in self
-            self.results
-                .get_or_insert(sensor_name)
-                .get_or_insert("b")
-                .get_or_insert("measured")
-                .insert("value", measured_this_sensor);
-            self.results
-                .get_or_insert(sensor_name)
-                .get_or_insert("b")
-                .get_or_insert("measured")
-                .insert("time", times_to_reconstruct.clone());
-        }
 
         // MDSplus is "Sensor-Major", but we want to rearrange the data to be "Time-Major"
         let mut results_dynamic: Vec<SensorsDynamic> = Vec::with_capacity(n_time);

--- a/rust/gsfit_rs/src/sensors/bp_probes.rs
+++ b/rust/gsfit_rs/src/sensors/bp_probes.rs
@@ -660,19 +660,20 @@ impl BpProbes {
                 let passive_r: Array1<f64> = passives.results.get(&passive_name).get("geometry").get("r").unwrap_array1();
                 let passive_z: Array1<f64> = passives.results.get(&passive_name).get("geometry").get("z").unwrap_array1();
 
+                // Green's table between this sensor and the passive's filaments (independent of the degrees of freedom)
+                let greens_calculator: Greens = Greens::sensor_to_conductor(
+                    array![sensor_r],
+                    array![sensor_z],
+                    passive_r.clone(),
+                    passive_z.clone(),
+                    passive_r.clone() * 0.0, // TODO: should this be NaN instead?
+                    passive_z.clone() * 0.0,
+                );
+
+                let g_br_matrix: Array2<f64> = greens_calculator.b_r(); // shape() = (1, n_filament)
+                let g_bz_matrix: Array2<f64> = greens_calculator.b_z(); // shape() = (1, n_filament)
+
                 for dof_name in dof_names {
-                    let greens_calculator: Greens = Greens::sensor_to_conductor(
-                        array![sensor_r],
-                        array![sensor_z],
-                        passive_r.clone(),
-                        passive_z.clone(),
-                        passive_r.clone() * 0.0, // TODO: should this be NaN instead?
-                        passive_z.clone() * 0.0,
-                    );
-
-                    let g_br_matrix: Array2<f64> = greens_calculator.b_r(); // shape() = (1, n_z*n_r)
-                    let g_bz_matrix: Array2<f64> = greens_calculator.b_z(); // shape() = (1, n_z*n_r)
-
                     // Current distribution
                     let current_distribution: Array1<f64> = passives
                         .results
@@ -682,8 +683,8 @@ impl BpProbes {
                         .get("current_distribution")
                         .unwrap_array1();
 
-                    let g_br_with_dof_full: Array2<f64> = g_br_matrix * &current_distribution; // shape = [n_passive_dof, n_filament]
-                    let g_bz_with_dof_full: Array2<f64> = g_bz_matrix * current_distribution; // shape = [n_passive_dof, n_filament]
+                    let g_br_with_dof_full: Array2<f64> = &g_br_matrix * &current_distribution; // shape = [1, n_filament]
+                    let g_bz_with_dof_full: Array2<f64> = &g_bz_matrix * &current_distribution; // shape = [1, n_filament]
 
                     // Sum over all filaments
                     let g_br: f64 = g_br_with_dof_full.sum(); // shape = [n_passive_dof]

--- a/rust/gsfit_rs/src/sensors/bp_probes.rs
+++ b/rust/gsfit_rs/src/sensors/bp_probes.rs
@@ -282,7 +282,7 @@ impl BpProbes {
     /// 1.) Static (non time-dependent) object. Note, it is here that the sensors are down-selected, based on ["fit_settings"]["include"]
     /// 2.) A Vec of time-dependent objects. Note, the length of the Vec is the number of time-slices we want to reconstruct
     /// TODO: change `SensorsStatic` to Vec<SensorsStatic> to be consistent with other sensor types.
-    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (Vec<SensorsStatic>, Vec<SensorsDynamic>) {
+    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (SensorsStatic, Vec<SensorsDynamic>) {
         let n_time: usize = times_to_reconstruct.len();
 
         // Vector of boolean's to say if we use the sensor or not
@@ -306,9 +306,8 @@ impl BpProbes {
         // If there are no sensors selected, return empty data
         if n_sensors == 0 {
             let (static_data_empty, dynamic_data_empty): (SensorsStatic, SensorsDynamic) = create_empty_sensor_data();
-            let static_data_empty_vs_time: Vec<SensorsStatic> = vec![static_data_empty; n_time];
             let dynamic_data_empty_vs_time: Vec<SensorsDynamic> = vec![dynamic_data_empty; n_time];
-            return (static_data_empty_vs_time, dynamic_data_empty_vs_time);
+            return (static_data_empty, dynamic_data_empty_vs_time);
         }
 
         // Fit settings
@@ -426,10 +425,8 @@ impl BpProbes {
             results_dynamic.push(results_dynamic_this_time_slice);
         }
 
-        let results_static_time_dependent: Vec<SensorsStatic> = vec![results_static.clone(); n_time];
-
-        // Return the static and dynamic results
-        (results_static_time_dependent, results_dynamic)
+        // The Green's tables do not depend on time, so a single static table is shared by all time-slices
+        (results_static, results_dynamic)
     }
 
     /// Calculate sensor values

--- a/rust/gsfit_rs/src/sensors/dialoop.rs
+++ b/rust/gsfit_rs/src/sensors/dialoop.rs
@@ -143,7 +143,7 @@ impl Dialoop {
     /// Diamagnetic loops do not use Green's functions: the response is computed directly from the
     /// ff' source function inside the GS solver (see `gs_solution.rs`). The Green's arrays below are
     /// therefore left empty.
-    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (Vec<SensorsStatic>, Vec<SensorsDynamic>) {
+    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (SensorsStatic, Vec<SensorsDynamic>) {
         let n_time: usize = times_to_reconstruct.len();
 
         // Vector of boolean's to say if we use the sensor or not
@@ -202,9 +202,8 @@ impl Dialoop {
         // If there are no sensors selected, return empty data
         if n_sensors == 0 {
             let (static_data_empty, dynamic_data_empty): (SensorsStatic, SensorsDynamic) = create_empty_sensor_data();
-            let static_data_empty_vs_time: Vec<SensorsStatic> = vec![static_data_empty; n_time];
             let dynamic_data_empty_vs_time: Vec<SensorsDynamic> = vec![dynamic_data_empty; n_time];
-            return (static_data_empty_vs_time, dynamic_data_empty_vs_time);
+            return (static_data_empty, dynamic_data_empty_vs_time);
         }
 
         // Fit settings
@@ -235,9 +234,8 @@ impl Dialoop {
             results_dynamic.push(results_dynamic_this_time_slice);
         }
 
-        let results_static_time_dependent: Vec<SensorsStatic> = vec![results_static.clone(); n_time];
-
-        (results_static_time_dependent, results_dynamic)
+        // The Green's tables do not depend on time, so a single static table is shared by all time-slices
+        (results_static, results_dynamic)
     }
 
     /// Calculate the diamagnetic flux for each sensor and time-slice from a reconstructed plasma.

--- a/rust/gsfit_rs/src/sensors/flux_loops.rs
+++ b/rust/gsfit_rs/src/sensors/flux_loops.rs
@@ -432,7 +432,7 @@ impl FluxLoops {
     /// This splits the FluxLoops into:
     /// 1.) Static (non time-dependent) object. Note, it is here that the sensors are down-selected, based on ["fit_settings"]["include"]
     /// 2.) A Vec of time-dependent objects. Note, the length of the Vec is the number of time-slices we want to reconstruct
-    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (Vec<SensorsStatic>, Vec<SensorsDynamic>) {
+    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (SensorsStatic, Vec<SensorsDynamic>) {
         let n_time: usize = times_to_reconstruct.len();
 
         // Vector of boolean's to say if we use the sensor or not
@@ -456,9 +456,8 @@ impl FluxLoops {
         // If there are no sensors selected, return empty data
         if n_sensors == 0 {
             let (static_data_empty, dynamic_data_empty): (SensorsStatic, SensorsDynamic) = create_empty_sensor_data();
-            let static_data_empty_vs_time: Vec<SensorsStatic> = vec![static_data_empty; n_time];
             let dynamic_data_empty_vs_time: Vec<SensorsDynamic> = vec![dynamic_data_empty; n_time];
-            return (static_data_empty_vs_time, dynamic_data_empty_vs_time);
+            return (static_data_empty, dynamic_data_empty_vs_time);
         }
 
         // Fit settings
@@ -578,10 +577,8 @@ impl FluxLoops {
             results_dynamic.push(results_dynamic_this_time_slice);
         }
 
-        let results_static_time_dependent: Vec<SensorsStatic> = vec![results_static.clone(); n_time];
-
-        // Return the static and dynamic results
-        (results_static_time_dependent, results_dynamic)
+        // The Green's tables do not depend on time, so a single static table is shared by all time-slices
+        (results_static, results_dynamic)
     }
 
     pub fn calculate_sensor_values_rs(&mut self, coils: &Coils, passives: &Passives, plasma: &Plasma) {

--- a/rust/gsfit_rs/src/sensors/flux_loops.rs
+++ b/rust/gsfit_rs/src/sensors/flux_loops.rs
@@ -453,6 +453,43 @@ impl FluxLoops {
         let sensor_names: Vec<String> = include_indices.iter().map(|&index| sensor_names_all[index].clone()).collect();
         let n_sensors: usize = sensor_names.len();
 
+        // Time dependent: interpolate all sensors (included or not) to `times_to_reconstruct` and store the
+        // measured values, so that they are available for the sensor post-processing even when no sensor
+        // of this type is included in the fit
+        let mut measured: Array2<f64> = Array2::from_elem((n_sensors_all, n_time), f64::NAN);
+        for i_sensor in 0..n_sensors_all {
+            // Sensor names
+            let sensor_name: &str = &sensor_names_all[i_sensor];
+
+            // Measured values
+            let experimental_time: Array1<f64> = self.results.get(sensor_name).get("psi").get("experimental").get("time").unwrap_array1();
+            let experimental_values: Array1<f64> = self.results.get(sensor_name).get("psi").get("experimental").get("value").unwrap_array1();
+
+            // Create the interpolator
+            let interpolator: interpolation::Dim1Linear = interpolation::Dim1Linear::new(experimental_time.clone(), experimental_values.clone())
+                .expect("FluxLoops.split_into_static_and_dynamic: Can't make interpolator");
+
+            // Do the interpolation
+            let measured_this_sensor: Array1<f64> = interpolator
+                .interpolate_array1(times_to_reconstruct)
+                .expect("FluxLoops.split_into_static_and_dynamic: Can't do interpolation");
+
+            // Store for later
+            measured.slice_mut(s![i_sensor, ..]).assign(&measured_this_sensor);
+
+            // Store in self
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("psi")
+                .get_or_insert("measured")
+                .insert("value", measured_this_sensor);
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("psi")
+                .get_or_insert("measured")
+                .insert("time", times_to_reconstruct.clone());
+        }
+
         // If there are no sensors selected, return empty data
         if n_sensors == 0 {
             let (static_data_empty, dynamic_data_empty): (SensorsStatic, SensorsDynamic) = create_empty_sensor_data();
@@ -528,42 +565,6 @@ impl FluxLoops {
             geometry_r: Array1::from_elem(n_sensors, f64::NAN), // not used for FluxLoops
             geometry_z: Array1::from_elem(n_sensors, f64::NAN), // not used for FluxLoops
         };
-
-        // Time dependent
-        // Interpolate all sensors to `times_to_reconstruct`
-        let mut measured: Array2<f64> = Array2::from_elem((n_sensors_all, n_time), f64::NAN);
-        for i_sensor in 0..n_sensors_all {
-            // Sensor names
-            let sensor_name: &str = &sensor_names_all[i_sensor];
-
-            // Measured values
-            let experimental_time: Array1<f64> = self.results.get(sensor_name).get("psi").get("experimental").get("time").unwrap_array1();
-            let experimental_values: Array1<f64> = self.results.get(sensor_name).get("psi").get("experimental").get("value").unwrap_array1();
-
-            // Create the interpolator
-            let interpolator: interpolation::Dim1Linear = interpolation::Dim1Linear::new(experimental_time.clone(), experimental_values.clone())
-                .expect("FluxLoops.split_into_static_and_dynamic: Can't make interpolator");
-
-            // Do the interpolation
-            let measured_this_sensor: Array1<f64> = interpolator
-                .interpolate_array1(times_to_reconstruct)
-                .expect("FluxLoops.split_into_static_and_dynamic: Can't do interpolation");
-
-            // Store for later
-            measured.slice_mut(s![i_sensor, ..]).assign(&measured_this_sensor);
-
-            // Store in self
-            self.results
-                .get_or_insert(sensor_name)
-                .get_or_insert("psi")
-                .get_or_insert("measured")
-                .insert("value", measured_this_sensor);
-            self.results
-                .get_or_insert(sensor_name)
-                .get_or_insert("psi")
-                .get_or_insert("measured")
-                .insert("time", times_to_reconstruct.clone());
-        }
 
         // MDSplus is "Sensor-Major", but we want to rearrange the data to be "Time-Major"
         let mut results_dynamic: Vec<SensorsDynamic> = Vec::with_capacity(n_time);

--- a/rust/gsfit_rs/src/sensors/flux_loops.rs
+++ b/rust/gsfit_rs/src/sensors/flux_loops.rs
@@ -138,17 +138,18 @@ impl FluxLoops {
                 let passive_r: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("r").unwrap_array1();
                 let passive_z: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("z").unwrap_array1();
 
-                for dof_name in dof_names {
-                    let greens_calculator: Greens = Greens::sensor_to_conductor(
-                        array![sensor_r],
-                        array![sensor_z],
-                        passive_r.clone(),
-                        passive_z.clone(),
-                        passive_r.clone() * 0.0, // TODO: should I set these to NaN?
-                        passive_z.clone() * 0.0,
-                    );
-                    let g_psi_matrix: Array2<f64> = greens_calculator.psi(); // shape = (1, passive_r.len())
+                // Green's table between this sensor and the passive's filaments (independent of the degrees of freedom)
+                let greens_calculator: Greens = Greens::sensor_to_conductor(
+                    array![sensor_r],
+                    array![sensor_z],
+                    passive_r.clone(),
+                    passive_z.clone(),
+                    passive_r.clone() * 0.0, // TODO: should I set these to NaN?
+                    passive_z.clone() * 0.0,
+                );
+                let g_psi_matrix: Array2<f64> = greens_calculator.psi(); // shape = (1, passive_r.len())
 
+                for dof_name in dof_names {
                     // Current distribution
                     let current_distribution: Array1<f64> = passives_local
                         .results
@@ -158,7 +159,7 @@ impl FluxLoops {
                         .get("current_distribution")
                         .unwrap_array1();
 
-                    let g_with_dof_full: Array2<f64> = g_psi_matrix * &current_distribution; // shape = [n_r * n_z, n_filament]
+                    let g_with_dof_full: Array2<f64> = &g_psi_matrix * &current_distribution; // shape = [1, n_filament]
 
                     // Sum over all filaments
                     let g: f64 = g_with_dof_full.sum(); // shape = [n_r * n_z]

--- a/rust/gsfit_rs/src/sensors/isoflux.rs
+++ b/rust/gsfit_rs/src/sensors/isoflux.rs
@@ -332,58 +332,55 @@ impl Isoflux {
                 let passive_r: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("r").unwrap_array1();
                 let passive_z: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("z").unwrap_array1();
 
+                // Green's tables between the (time-dependent) isoflux locations and the passive's filaments;
+                // these do not depend on the degrees of freedom, so they are calculated once per time-slice
+                let mut g_full_location_1_vs_time: Vec<Array2<f64>> = Vec::with_capacity(n_time);
+                let mut g_full_location_2_vs_time: Vec<Array2<f64>> = Vec::with_capacity(n_time);
+                for i_time in 0..n_time {
+                    // Location 1
+                    let greens_calculator: Greens = Greens::sensor_to_conductor(
+                        array![location_1_r[i_time]],
+                        array![location_1_z[i_time]],
+                        passive_r.clone(),
+                        passive_z.clone(),
+                        passive_r.clone() * 0.0,
+                        passive_z.clone() * 0.0,
+                    );
+                    g_full_location_1_vs_time.push(greens_calculator.psi()); // shape = [1, n_filaments]
+
+                    // Location 2
+                    let greens_calculator: Greens = Greens::sensor_to_conductor(
+                        array![location_2_r[i_time]],
+                        array![location_2_z[i_time]],
+                        passive_r.clone(),
+                        passive_z.clone(),
+                        passive_r.clone() * 0.0,
+                        passive_z.clone() * 0.0,
+                    );
+                    g_full_location_2_vs_time.push(greens_calculator.psi()); // shape = [1, n_filaments]
+                }
+
                 // Loop over all degrees of freedom
                 for dof_name in dof_names {
+                    // Current distribution
+                    let current_distribution: Array1<f64> = passives
+                        .results
+                        .get(&passive_name)
+                        .get("dof")
+                        .get(&dof_name)
+                        .get("current_distribution")
+                        .unwrap_array1();
+
                     let mut g_vs_time: Array1<f64> = Array1::zeros(n_time);
                     for i_time in 0..n_time {
                         // Location 1
-                        let greens_calculator: Greens = Greens::sensor_to_conductor(
-                            array![location_1_r[i_time]],
-                            array![location_1_z[i_time]],
-                            passive_r.clone(),
-                            passive_z.clone(),
-                            passive_r.clone() * 0.0,
-                            passive_z.clone() * 0.0,
-                        );
-
-                        let g_full_location_1: Array2<f64> = greens_calculator.psi(); // shape = [1, n_filaments]
-
-                        // Current distribution
-                        let current_distribution: Array1<f64> = passives
-                            .results
-                            .get(&passive_name)
-                            .get("dof")
-                            .get(&dof_name)
-                            .get("current_distribution")
-                            .unwrap_array1();
-
-                        let g_with_dof_full_location_1: Array2<f64> = g_full_location_1 * &current_distribution; // shape = [n_r * n_z, n_filament]
+                        let g_with_dof_full_location_1: Array2<f64> = &g_full_location_1_vs_time[i_time] * &current_distribution; // shape = [1, n_filament]
 
                         // Sum over all filaments
                         let g_location_1: f64 = g_with_dof_full_location_1.sum();
 
                         // Location 2
-                        let greens_calculator: Greens = Greens::sensor_to_conductor(
-                            array![location_2_r[i_time]],
-                            array![location_2_z[i_time]],
-                            passive_r.clone(),
-                            passive_z.clone(),
-                            passive_r.clone() * 0.0,
-                            passive_z.clone() * 0.0,
-                        );
-
-                        let g_full_location_2: Array2<f64> = greens_calculator.psi(); // shape = [1, n_filaments]
-
-                        // Current distribution
-                        let current_distribution: Array1<f64> = passives
-                            .results
-                            .get(&passive_name)
-                            .get("dof")
-                            .get(&dof_name)
-                            .get("current_distribution")
-                            .unwrap_array1();
-
-                        let g_with_dof_full_location_2: Array2<f64> = g_full_location_2 * &current_distribution; // shape = [n_r * n_z, n_filament]
+                        let g_with_dof_full_location_2: Array2<f64> = &g_full_location_2_vs_time[i_time] * &current_distribution; // shape = [1, n_filament]
 
                         // Sum over all filaments
                         let g_location_2: f64 = g_with_dof_full_location_2.sum();

--- a/rust/gsfit_rs/src/sensors/isoflux_boundary.rs
+++ b/rust/gsfit_rs/src/sensors/isoflux_boundary.rs
@@ -247,31 +247,35 @@ impl IsofluxBoundary {
                 let passive_r: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("r").unwrap_array1();
                 let passive_z: Array1<f64> = passives_local.results.get(&passive_name).get("geometry").get("z").unwrap_array1();
 
+                // Green's tables between the (time-dependent) location and the passive's filaments;
+                // these do not depend on the degrees of freedom, so they are calculated once per time-slice
+                let mut g_full_location_1_vs_time: Vec<Array2<f64>> = Vec::with_capacity(n_time);
+                for i_time in 0..n_time {
+                    let greens_calculator: Greens = Greens::sensor_to_conductor(
+                        array![location_1_r[i_time]],
+                        array![location_1_z[i_time]],
+                        passive_r.clone(),
+                        passive_z.clone(),
+                        passive_r.clone() * 0.0,
+                        passive_z.clone() * 0.0,
+                    );
+                    g_full_location_1_vs_time.push(greens_calculator.psi()); // shape = [1, n_filaments]
+                }
+
                 // Loop over all degrees of freedom
                 for dof_name in dof_names {
+                    // Current distribution
+                    let current_distribution: Array1<f64> = passives
+                        .results
+                        .get(&passive_name)
+                        .get("dof")
+                        .get(&dof_name)
+                        .get("current_distribution")
+                        .unwrap_array1();
+
                     let mut g_vs_time: Array1<f64> = Array1::from_elem(n_time, f64::NAN);
                     for i_time in 0..n_time {
-                        // Location 1
-                        let greens_calculator: Greens = Greens::sensor_to_conductor(
-                            array![location_1_r[i_time]],
-                            array![location_1_z[i_time]],
-                            passive_r.clone(),
-                            passive_z.clone(),
-                            passive_r.clone() * 0.0,
-                            passive_z.clone() * 0.0,
-                        );
-                        let g_full_location_1: Array2<f64> = greens_calculator.psi(); // shape = [1, n_z * n_r]
-
-                        // Current distribution
-                        let current_distribution: Array1<f64> = passives
-                            .results
-                            .get(&passive_name)
-                            .get("dof")
-                            .get(&dof_name)
-                            .get("current_distribution")
-                            .unwrap_array1();
-
-                        let g_with_dof_full_location_1: Array2<f64> = g_full_location_1 * &current_distribution; // shape = [n_r * n_z, n_filament]
+                        let g_with_dof_full_location_1: Array2<f64> = &g_full_location_1_vs_time[i_time] * &current_distribution; // shape = [1, n_filament]
 
                         // Sum over all filaments
                         g_vs_time[i_time] = g_with_dof_full_location_1.sum();

--- a/rust/gsfit_rs/src/sensors/rogowski_coils.rs
+++ b/rust/gsfit_rs/src/sensors/rogowski_coils.rs
@@ -685,6 +685,42 @@ impl RogowskiCoils {
         let sensor_names: Vec<String> = include_indices.iter().map(|&index| sensor_names_all[index].clone()).collect();
         let n_sensors: usize = sensor_names.len();
 
+        // Time dependent: interpolate all sensors (included or not) to `times_to_reconstruct` and store the
+        // measured values, so that they are available for the sensor post-processing even when no sensor
+        // of this type is included in the fit
+        let mut measured: Array2<f64> = Array2::from_elem((n_sensors_all, n_time), f64::NAN);
+        for i_sensor in 0..n_sensors_all {
+            // Sensor names
+            let sensor_name: &str = &sensor_names_all[i_sensor];
+
+            // Measured values
+            let experimental_time: Array1<f64> = self.results.get(sensor_name).get("i").get("experimental").get("time").unwrap_array1();
+            let experimental_values: Array1<f64> = self.results.get(sensor_name).get("i").get("experimental").get("value").unwrap_array1();
+
+            // Create the interpolator
+            let interpolator: interpolation::Dim1Linear = interpolation::Dim1Linear::new(experimental_time.clone(), experimental_values.clone())
+                .expect("RogowskiCoils.split_into_static_and_dynamic: Can't make interpolator");
+            // Do the interpolation
+            let measured_this_coil: Array1<f64> = interpolator
+                .interpolate_array1(times_to_reconstruct)
+                .expect("RogowskiCoils.split_into_static_and_dynamic: Can't do interpolation");
+
+            // Store for later
+            measured.slice_mut(s![i_sensor, ..]).assign(&measured_this_coil);
+
+            // Store in self
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("i")
+                .get_or_insert("measured")
+                .insert("value", measured_this_coil);
+            self.results
+                .get_or_insert(sensor_name)
+                .get_or_insert("i")
+                .get_or_insert("measured")
+                .insert("time", times_to_reconstruct.clone());
+        }
+
         // If there are no sensors selected, return empty data
         if n_sensors == 0 {
             let (static_data_empty, dynamic_data_empty): (SensorsStatic, SensorsDynamic) = create_empty_sensor_data();
@@ -760,41 +796,6 @@ impl RogowskiCoils {
             geometry_r: Array1::from_elem(n_sensors, f64::NAN), // not used for RogowskiCoils
             geometry_z: Array1::from_elem(n_sensors, f64::NAN), // not used for RogowskiCoils
         };
-
-        // Time dependent
-        // Interpolate all sensors to `times_to_reconstruct`
-        let mut measured: Array2<f64> = Array2::from_elem((n_sensors_all, n_time), f64::NAN);
-        for i_sensor in 0..n_sensors_all {
-            // Sensor names
-            let sensor_name: &str = &sensor_names_all[i_sensor];
-
-            // Measured values
-            let experimental_time: Array1<f64> = self.results.get(sensor_name).get("i").get("experimental").get("time").unwrap_array1();
-            let experimental_values: Array1<f64> = self.results.get(sensor_name).get("i").get("experimental").get("value").unwrap_array1();
-
-            // Create the interpolator
-            let interpolator: interpolation::Dim1Linear = interpolation::Dim1Linear::new(experimental_time.clone(), experimental_values.clone())
-                .expect("RogowskiCoils.split_into_static_and_dynamic: Can't make interpolator");
-            // Do the interpolation
-            let measured_this_coil: Array1<f64> = interpolator
-                .interpolate_array1(times_to_reconstruct)
-                .expect("RogowskiCoils.split_into_static_and_dynamic: Can't do interpolation");
-
-            // Store for later
-            measured.slice_mut(s![i_sensor, ..]).assign(&measured_this_coil);
-
-            // Store in self
-            self.results
-                .get_or_insert(sensor_name)
-                .get_or_insert("i")
-                .get_or_insert("measured")
-                .insert("value", measured_this_coil);
-            self.results
-                .get_or_insert(sensor_name)
-                .get_or_insert("i")
-                .get_or_insert("measured")
-                .insert("time", times_to_reconstruct.clone());
-        }
 
         // MDSplus is "Sensor-Major", but we want to rearrange the data to be "Time-Major"
         let mut results_dynamic: Vec<SensorsDynamic> = Vec::with_capacity(n_time);

--- a/rust/gsfit_rs/src/sensors/rogowski_coils.rs
+++ b/rust/gsfit_rs/src/sensors/rogowski_coils.rs
@@ -294,6 +294,21 @@ impl RogowskiCoils {
                 vec![], // No holes
             );
 
+            // Virtual bp-probes along each gap, with their Green's tables against all passive degrees of freedom.
+            // These depend only on the gap geometry, so they are constructed once per gap (not per passive dof)
+            let mut virtual_bp_probes_per_gap: Vec<(BpProbes, BpProbes, f64, f64)> = Vec::with_capacity(gap_names.len());
+            for gap_name in &gap_names {
+                // Construct virtual bp probes
+                let (mut virtual_b_r_probes, mut virtual_b_z_probes, gap_virtual_d_r, gap_virtual_d_z) =
+                    self.construct_virtual_bp_probes(&sensor_name, gap_name);
+
+                // Calculate Greens betwen the virtual bp-probes and the passives
+                virtual_b_r_probes.greens_with_passives_rs(passives_local.clone());
+                virtual_b_z_probes.greens_with_passives_rs(passives_local.clone());
+
+                virtual_bp_probes_per_gap.push((virtual_b_r_probes, virtual_b_z_probes, gap_virtual_d_r, gap_virtual_d_z));
+            }
+
             // Calculate Greens with each passive degree of freedom
             for passive_name in passives_local.results.keys() {
                 let _tmp: DataTreeAccumulator<'_> = passives_local.results.get(&passive_name).get("dof");
@@ -324,18 +339,11 @@ impl RogowskiCoils {
 
                     let g_all: Array1<f64> = &inside_vec * current_distribution;
 
-                    // Calculate the greens for the gaps (needed for later)
-                    // TODO: this is wasteful as we are re-calculating the same thing
-                    // (at least there are not many PF coils. but still not good...)
+                    // Calculate the greens for the gaps
                     let mut g_gap: f64 = 0.0;
-                    for gap_name in &gap_names {
-                        // Construct virtual bp probes
-                        let (mut virtual_b_r_probes, mut virtual_b_z_probes, gap_virtual_d_r, gap_virtual_d_z) =
-                            self.construct_virtual_bp_probes(&sensor_name, gap_name);
-
-                        // Calculate Greens betwen the virtual bp-probes and the coils
-                        virtual_b_r_probes.greens_with_passives_rs(passives_local.clone());
-                        virtual_b_z_probes.greens_with_passives_rs(passives_local.clone());
+                    for (virtual_b_r_probes, virtual_b_z_probes, gap_virtual_d_r, gap_virtual_d_z) in &virtual_bp_probes_per_gap {
+                        let gap_virtual_d_r: f64 = *gap_virtual_d_r;
+                        let gap_virtual_d_z: f64 = *gap_virtual_d_z;
 
                         let g_gaps_b_r: Array1<f64> = virtual_b_r_probes
                             .results

--- a/rust/gsfit_rs/src/sensors/rogowski_coils.rs
+++ b/rust/gsfit_rs/src/sensors/rogowski_coils.rs
@@ -664,7 +664,7 @@ impl RogowskiCoils {
     /// This splits the RogowskiCoils into:
     /// 1.) Static (non time-dependent) object. Note, it is here that the sensors are down-selected, based on ["fit_settings"]["include"]
     /// 2.) A Vec of time-dependent objects. Note, the length of the Vec is the number of time-slices we want to reconstruct
-    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (Vec<SensorsStatic>, Vec<SensorsDynamic>) {
+    pub fn split_into_static_and_dynamic(&mut self, times_to_reconstruct: &Array1<f64>) -> (SensorsStatic, Vec<SensorsDynamic>) {
         let n_time: usize = times_to_reconstruct.len();
 
         // Vector of boolean's to say if we use the sensor or not
@@ -688,9 +688,8 @@ impl RogowskiCoils {
         // If there are no sensors selected, return empty data
         if n_sensors == 0 {
             let (static_data_empty, dynamic_data_empty): (SensorsStatic, SensorsDynamic) = create_empty_sensor_data();
-            let static_data_empty_vs_time: Vec<SensorsStatic> = vec![static_data_empty; n_time];
             let dynamic_data_empty_vs_time: Vec<SensorsDynamic> = vec![dynamic_data_empty; n_time];
-            return (static_data_empty_vs_time, dynamic_data_empty_vs_time);
+            return (static_data_empty, dynamic_data_empty_vs_time);
         }
 
         // Fit settings
@@ -809,10 +808,8 @@ impl RogowskiCoils {
             results_dynamic.push(results_dynamic_this_time_slice);
         }
 
-        let results_static_time_dependent: Vec<SensorsStatic> = vec![results_static.clone(); n_time];
-
-        // Return the static and dynamic results
-        (results_static_time_dependent, results_dynamic)
+        // The Green's tables do not depend on time, so a single static table is shared by all time-slices
+        (results_static, results_dynamic)
     }
 
     pub fn calculate_sensor_values_rs(&mut self, coils: &Coils, passives: &Passives, plasma: &Plasma) {

--- a/rust/gsfit_rs/src/sensors/stationary_point.rs
+++ b/rust/gsfit_rs/src/sensors/stationary_point.rs
@@ -483,30 +483,34 @@ impl StationaryPoint {
                 let passive_r: Array1<f64> = passives.results.get(&passive_name).get("geometry").get("r").unwrap_array1();
                 let passive_z: Array1<f64> = passives.results.get(&passive_name).get("geometry").get("z").unwrap_array1();
 
+                // Green's tables between the (time-dependent) magnetic axis and the passive's filaments;
+                // these do not depend on the degrees of freedom, so they are calculated once per time-slice
+                let mut g_br_full_vs_time: Vec<Array2<f64>> = Vec::with_capacity(n_time);
+                for i_time in 0..n_time {
+                    let greens_calculator: Greens = Greens::sensor_to_conductor(
+                        array![mag_axis_r[i_time]], // sensor
+                        array![mag_axis_z[i_time]],
+                        passive_r.clone(), // current source
+                        passive_z.clone(),
+                        Array1::zeros(passive_r.len()), // TODO: should this be NaN?
+                        Array1::zeros(passive_r.len()),
+                    );
+                    g_br_full_vs_time.push(greens_calculator.b_r()); // shape = [1, n_passive_filament]
+                }
+
                 for dof_name in dof_names {
+                    // Current distribution
+                    let current_distribution: Array1<f64> = passives
+                        .results
+                        .get(&passive_name)
+                        .get("dof")
+                        .get(&dof_name)
+                        .get("current_distribution")
+                        .unwrap_array1();
+
                     let mut g_vs_time: Array1<f64> = Array1::from_elem(n_time, f64::NAN);
                     for i_time in 0..n_time {
-                        let greens_calculator: Greens = Greens::sensor_to_conductor(
-                            array![mag_axis_r[i_time]], // sensor
-                            array![mag_axis_z[i_time]],
-                            passive_r.clone(), // current source
-                            passive_z.clone(),
-                            Array1::zeros(passive_r.len()), // TODO: should this be NaN?
-                            Array1::zeros(passive_r.len()),
-                        );
-
-                        let g_br_full: Array2<f64> = greens_calculator.b_r(); // shape = [n_sensor, n_passive_filament]
-
-                        // Current distribution
-                        let current_distribution: Array1<f64> = passives
-                            .results
-                            .get(&passive_name)
-                            .get("dof")
-                            .get(&dof_name)
-                            .get("current_distribution")
-                            .unwrap_array1();
-
-                        let g_br_with_dof_full: Array2<f64> = g_br_full * &current_distribution; // shape = [n_passive_dof, n_filament]
+                        let g_br_with_dof_full: Array2<f64> = &g_br_full_vs_time[i_time] * &current_distribution; // shape = [1, n_filament]
 
                         // Sum over all filaments
                         let g_br: f64 = g_br_with_dof_full.sum(); // shape = [n_passive_dof]

--- a/tests/test_03_sensor_type_with_no_included_sensors/test_03_sensor_type_with_no_included_sensors.py
+++ b/tests/test_03_sensor_type_with_no_included_sensors/test_03_sensor_type_with_no_included_sensors.py
@@ -1,0 +1,71 @@
+"""
+Regression test:
+A reconstruction must still run when a whole sensor type has no sensors included in the fit.
+
+Background
+----------
+Excluding every bp probe (or every flux loop) from the fit is a legitimate way to test the
+sensitivity of a reconstruction to a diagnostic. Two failures used to occur:
+
+* the number of passive degrees of freedom was read from the bp-probe Green's table, which is
+  empty when no bp probe is included, so the passive currents had the wrong length and the
+  solver panicked in a matrix product;
+* the measured values of an excluded sensor type were never stored, so the sensor
+  post-processing (calculated values, chi_mag) panicked on a missing key.
+
+The shot data is read from the mocked MDSplus trees used by `test_02`, so the test needs no
+database, network, or `st40_database` dependency.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from gsfit import Gsfit
+
+MOCK_DIR = str(Path(__file__).parent.parent / "test_02_delta_z_shift_greater_than_d_z" / "data")
+WORKFLOW = {
+    "elmag": {"tree_name": "ELMAG", "pulseNo": None, "run_name": "RUN16", "usage": "Vessel and limiter geometry and resistance"},
+    "elmag_coils": {"tree_name": "ELMAG", "pulseNo": 11012050, "run_name": "RUN16", "usage": "PF coil geometry, from the machine description pulse"},
+    "mag": {"tree_name": "MAG", "pulseNo": None, "run_name": "BEST", "usage": "Magnetic sensors geometry and measured values"},
+    "psu2coil": {"tree_name": "PSU2COIL", "pulseNo": None, "run_name": "RUN02", "usage": "PF and TF coil currents"},
+    "rog_gaps": {"tree_name": "MAG", "pulseNo": 11010605, "run_name": "RUN14C", "usage": "INIVC000 Rogowski coil gaps"},
+}
+
+
+def make_controller() -> Gsfit:
+    gsfit_controller = Gsfit(
+        pulseNo=12050,
+        run_name="TEST_NO_SENSORS",
+        run_description="sensor type with no included sensors",
+        settings_path="default",
+        write_to_mds=False,
+    )
+    code_settings = gsfit_controller.settings["GSFIT_code_settings.json"]
+    code_settings["database_reader"]["method"] = "mock_st40_mdsplus"
+    code_settings["database_reader"]["mock_st40_mdsplus"] = {"mock_dir": MOCK_DIR, "workflow": WORKFLOW}
+    code_settings["timeslices"]["method"] = "user_defined"
+    code_settings["timeslices"]["user_defined"] = [130e-3]  # 130 ms
+    return gsfit_controller
+
+
+@pytest.mark.parametrize("sensor_weights_file", ["sensor_weights_bp_probe.json", "sensor_weights_flux_loops.json"])
+def test_03_sensor_type_with_no_included_sensors(sensor_weights_file: str) -> None:
+    gsfit_controller = make_controller()
+
+    # Exclude every sensor of this type from the fit
+    for sensor_settings in gsfit_controller.settings[sensor_weights_file].values():
+        if isinstance(sensor_settings, dict) and "fit_settings" in sensor_settings:
+            sensor_settings["fit_settings"]["include"] = False
+
+    gsfit_controller.run()
+
+    plasma = gsfit_controller.plasma
+    ip = plasma.get_array1(["global", "ip"])[0]
+    chi_mag = plasma.get_array1(["global", "chi_mag"])[0]
+    assert np.isfinite(ip), "GS reconstruction failed, should have converged without this sensor type"
+    assert np.isfinite(chi_mag), "chi_mag should still be calculated from the remaining sensor types"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "--capture=no", "--verbose"]))


### PR DESCRIPTION
Offline reconstruction throughput on the public workloads, at unchanged accuracy.

| Metric and workload | Before | After | Improvement |
| --- | --- | --- | --- |
| ST40 default workflow length on public mock data (480 slices, 81 x 161, setup + Green's tables + solve), wall time | 293 s | 39 s | 7.6x |
| ST40 mock, 31 slices, wall time | 71.0 s | 15.8 s | 4.5x |
| ST40 mock, 31 slices, flux map vs reference (max relative) | reference | 1.8e-11, identical iteration counts | unchanged within rounding |
| MAST-U FreeGSNKE example 02, GSFit part (1 slice, two solves) | 4.45 s | 3.07 s | 1.5x; results agree to 1e-14 |
| Robustness matrix, cases running to completion | 12 of 14 (2 crash) | 14 of 14 | outcomes and iteration counts otherwise identical |

The time went into work that was repeated far more often than it changes. The Green's tables between each passive conductor's filaments and the plasma grid, sensors and Rogowski gaps were recomputed for every passive degree of freedom (15x for the ST40 IVC), and the finite-size mutual-inductance quadrature ran serially; they are now computed once per passive and in parallel, with identical arithmetic. Inside the time-slice solver, the reorganised Green's tables, the inside-vessel mask and the static sensor tables were rebuilt per slice or per Picard iteration and are now built once per run; the source-function basis and the PF-coil fields are reused within an iteration and a slice; the stationary-point search skips cells without edge crossings; and the post-processing runs in parallel over slices. The one algorithmic change is the plasma Green's convolution: because the grid is uniform in z, the contribution of the plasma current to psi and its eight derivatives is a one-dimensional convolution along z for every radial pair, so it is now evaluated with real FFTs (O(n_r^2 n_z log n_z) per iteration) instead of a 3 GFLOP dense matrix product, computing the same double sum in a different floating-point order. Two crashes for sensor types with no included sensors are fixed with a regression test. Measured on an Apple M4 laptop with 8 rayon threads, release profile, medians of three alternating runs against upstream 2f6fd0c, on the public ST40 mocked-MDSplus and MAST-U FreeGSNKE workloads.

Evidence, method and reproduction: [`documentation/performance/2026-09-offline-throughput.md`](https://github.com/philippbogdan/gsfit/blob/perf/offline-throughput/documentation/performance/2026-09-offline-throughput.md) (per-phase timings, the 14-case robustness matrix, the benchmark scripts under `documentation/performance/benchmarks/`). Hardware: Apple M4 laptop, `RAYON_NUM_THREADS=8`, release profile; medians of three alternating runs against upstream `2f6fd0c`. Not measured on Tokamak Energy's machines or with MDSplus I/O.

Notes for review: the commits are independent and each was checked to be bitwise identical to the previous one on the ST40 mock workload, except the FFT commit, whose results differ from the dense product at the floating-point rounding level: flux, boundary, Ip, chi_mag and profiles agree to about 1e-10 relative with identical iteration counts on the ST40 slices and MAST-U example 02. Two cases converge along a different Picard path (one ST40 slice whose reference gs_error was 4.99999999e-6 against a 5e-6 tolerance, and the near-double-null example 07); the reference build shows the same behaviour under a 1e-14 perturbation of the fit weights, as documented. One new dependency, `realfft`. Several of the touched files are also modified on `imas_as_internal_data_structure`; the changes here are local to the Green's table construction, `GsSolution`, the post-processor and the stationary-point search, so they should carry over, but I am happy to rebase onto that branch instead if preferred.
